### PR TITLE
Define cycle in seconds and immediately deregister tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `darknode-sol`
 ## Solidity smart contracts used by Ren Darknodes
 
-[![Build Status](https://travis-ci.org/republicprotocol/republic-sol.svg?branch=master)](https://travis-ci.org/republicprotocol/republic-sol)
+[![CircleCI](https://circleci.com/gh/renproject/darknode-sol.svg?style=svg)](https://circleci.com/gh/renproject/darknode-sol)
 [![Coverage Status](https://coveralls.io/repos/github/republicprotocol/republic-sol/badge.svg?branch=master)](https://coveralls.io/github/republicprotocol/republic-sol?branch=master)
 
 **`darknode-sol`** contains a collection of Ethereum smart contracts utilized by the Ren Darknodes, written in Solidity. Ren bootstraps off Ethereum as a trusted third-party computer to handle Darknode registration and fee payouts.

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Ren is powered by the RenVM — the Ren Virtual Machine — in a decentralized n
 Install the dependencies.
 
 ```
-npm install
+yarn install
 ```
 
 Run the `ganache-cli` or an alternate Ethereum test RPC server on port 8545. The `-d` flag will use a deterministic mnemonic for reproducibility.
 
 ```sh
-npx ganache-cli -d
+yarn ganache-cli -d
 ```
 
 Run the Truffle test suite.
 
 ```sh
-npm run test
+yarn run test
 ```
 
 ## Coverage
@@ -38,13 +38,13 @@ npm run test
 Install the dependencies.
 
 ```
-npm install
+yarn install
 ```
 
 Run the Truffle test suite with coverage.
 
 ```sh
-npm run coverage
+yarn run coverage
 ```
 
 ## Deploying
@@ -52,5 +52,5 @@ npm run coverage
 Deploy to Kovan:
 
 ```sh
-npm run deployToKovan
+yarn run deployToKovan
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `darknode-sol`
 ## Solidity smart contracts used by Ren Darknodes
 
-[![CircleCI](https://circleci.com/gh/renproject/darknode-sol.svg?style=svg)](https://circleci.com/gh/renproject/darknode-sol)
+[![CircleCI](https://circleci.com/gh/renproject/darknode-sol.svg?style=shield)](https://circleci.com/gh/renproject/darknode-sol)
 [![Coverage Status](https://coveralls.io/repos/github/republicprotocol/republic-sol/badge.svg?branch=master)](https://coveralls.io/github/republicprotocol/republic-sol?branch=master)
 
 **`darknode-sol`** contains a collection of Ethereum smart contracts utilized by the Ren Darknodes, written in Solidity. Ren bootstraps off Ethereum as a trusted third-party computer to handle Darknode registration and fee payouts.

--- a/contracts/DarknodePayment/DarknodePayment.sol
+++ b/contracts/DarknodePayment/DarknodePayment.sol
@@ -39,9 +39,6 @@ contract DarknodePayment is Ownable {
     ///         prevent the number of shares from changing.
     address[] public pendingTokens;
 
-    /// @notice The list of tokens that will be deregistered next cycle.
-    address[] public pendingDeregisterTokens;
-
     /// @notice The list of tokens which are already registered and rewards can
     ///         be claimed for.
     address[] public registeredTokens;
@@ -291,11 +288,7 @@ contract DarknodePayment is Ownable {
     /// @param _token The address of the token to be deregistered.
     function deregisterToken(address _token) external onlyOwner {
         require(registeredTokenIndex[_token] > 0, "token not registered");
-        uint arrayLength = pendingDeregisterTokens.length;
-        for (uint i = 0; i < arrayLength; i++) {
-            require(pendingDeregisterTokens[i] != _token, "token already pending deregistration");
-        }
-        pendingDeregisterTokens.push(_token);
+        _deregisterToken(_token);
     }
 
     /// @notice Updates the Blacklister contract address.
@@ -380,12 +373,12 @@ contract DarknodePayment is Ownable {
         // So we don't need to manually delete the element
         registeredTokens.length = registeredTokens.length.sub(1);
         registeredTokenIndex[_token] = 0;
+
+        emit LogTokenDeregistered(_token);
     }
 
-    /// @notice Updates the list of registeredTokens removing tokens that need
-    ///         to be deregistered and adding tokens that are to be registered.
-    ///         The list of tokens that are pending registration or
-    ///         deregistration are emptied afterwards.
+    /// @notice Updates the list of registeredTokens adding tokens that are to be registered.
+    ///         The list of tokens that are pending registration are emptied afterwards.
     function _updateTokenList() private {
         // Register tokens
         uint arrayLength = pendingTokens.length;
@@ -396,14 +389,6 @@ contract DarknodePayment is Ownable {
             emit LogTokenRegistered(token);
         }
         pendingTokens.length = 0;
-        // Deregister tokens
-        arrayLength = pendingDeregisterTokens.length;
-        for (uint i = 0; i < arrayLength; i++) {
-            address token = pendingDeregisterTokens[i];
-            _deregisterToken(token);
-            emit LogTokenDeregistered(token);
-        }
-        pendingDeregisterTokens.length = 0;
     }
 
 }

--- a/contracts/DarknodePayment/DarknodePayment.sol
+++ b/contracts/DarknodePayment/DarknodePayment.sol
@@ -149,18 +149,17 @@ contract DarknodePayment is Ownable {
     /// @param _darknodeRegistry The address of the DarknodeRegistry contract
     /// @param _darknodePaymentStore The address of the DarknodePaymentStore
     ///        contract
-    /// @param _cycleDuration The minimum time before a new cycle can occur, in
-    ///        days
+    /// @param _cycleDurationSecs The minimum time before a new cycle can occur in seconds
     constructor(
         string memory _VERSION,
         DarknodeRegistry _darknodeRegistry,
         DarknodePaymentStore _darknodePaymentStore,
-        uint256 _cycleDuration
+        uint256 _cycleDurationSecs
     ) public {
         VERSION = _VERSION;
         darknodeRegistry = _darknodeRegistry;
         store = _darknodePaymentStore;
-        cycleDuration = _cycleDuration.mul(1 days);
+        cycleDuration = _cycleDurationSecs;
         // Default the blacklister to owner
         blacklister = msg.sender;
 

--- a/migrations/1_deploy_contracts.js
+++ b/migrations/1_deploy_contracts.js
@@ -99,6 +99,6 @@ module.exports = async function (deployer, network) {
             await darknodePayment.registerToken(token);
         }
         await darknodePayment.changeCycle();
-        await darknodePayment.updateCycleDuration(config.DARKNODE_PAYMENT_CYCLE_DURATION);
+        await darknodePayment.updateCycleDuration(config.DARKNODE_PAYMENT_CYCLE_DURATION_SECS);
     }
 }

--- a/migrations/1_deploy_contracts.js
+++ b/migrations/1_deploy_contracts.js
@@ -1,6 +1,5 @@
 /// <reference types="../test-ts/typings/truffle" />
 
-const CompatibleERC20Functions = artifacts.require("CompatibleERC20Functions");
 const RenToken = artifacts.require("RenToken");
 const DarknodePayment = artifacts.require("DarknodePayment");
 const DarknodePaymentStore = artifacts.require("DarknodePaymentStore");

--- a/migrations/config.js
+++ b/migrations/config.js
@@ -5,5 +5,5 @@ module.exports = {
     MINIMUM_BOND: new BN(100000).mul(new BN(10).pow(new BN(18))),
     MINIMUM_POD_SIZE: 3, // 24 in production
     MINIMUM_EPOCH_INTERVAL: 2, // 14400 in production
-    DARKNODE_PAYMENT_CYCLE_DURATION: 7, // 30 in production (in days)
+    DARKNODE_PAYMENT_CYCLE_DURATION_SECS: 300, // (5 minutes in secs), 2628000 in production (1 month in secs)
 }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "repository": "https://github.io/renproject/darknode-sol",
   "scripts": {
     "clean": "if [ -d \"test\" ]; then rm -r test; fi;",
-    "test": "if [ -d \"test\" ]; then npm run warn; else npm run test:ts; fi;",
-    "coverage": "if [ -d \"test\" ]; then npm run warn; else npm run coverage:ts; fi;",
+    "test": "if [ -d \"test\" ]; then yarn run warn; else yarn run test:ts; fi;",
+    "coverage": "if [ -d \"test\" ]; then yarn run warn; else yarn run coverage:ts; fi;",
     "merge": "sol-merger \"./contracts/**/*.sol\"",
-    "warn": "echo \"Refusing to overwrite 'test' directory. Run '\\033[1;33mnpm run clean\\033[0m'.\n\"",
-    "test:ts": "trap \"npm run clean\" INT TERM; (npm run bindings:ts && tsc && truffle test); npm run clean",
-    "coverage:ts": "trap \"npm run clean\" INT TERM; (npm run bindings:ts && tsc && solidity-coverage); npm run clean",
+    "warn": "echo \"Refusing to overwrite 'test' directory. Run '\\033[1;33myarn run clean\\033[0m'.\n\"",
+    "test:ts": "trap \"yarn run clean\" INT TERM; (yarn run bindings:ts && tsc && truffle test); yarn run clean",
+    "coverage:ts": "trap \"yarn run clean\" INT TERM; (yarn run bindings:ts && tsc && solidity-coverage); yarn run clean",
     "bindings:ts": "truffle compile && ./node_modules/.bin/abi-gen --abis 'build/contracts/*.json' --output ./test-ts/typings/bindings --template './test-ts/typings/bindings/templates/contract.handlebars' --partials './test-ts/typings/bindings/templates/partials/*.handlebars' 1> /dev/null",
     "bindings:go": "solc --allow-paths . --combined-json bin,abi,userdoc,devdoc,metadata contracts/**/*.sol | abigen -pkg bindings --out bindings.go --abi -",
-    "deployToKovan": "truffle migrate --network kovan && npm run merge .merged/kovan",
+    "deployToKovan": "truffle migrate --network kovan && yarn run merge .merged/kovan",
     "postinstall": "patch-package"
   },
   "dependencies": {
@@ -56,3 +56,4 @@
     "solc": "^0.5.7"
   }
 }
+

--- a/test-ts/DarknodePayment.ts
+++ b/test-ts/DarknodePayment.ts
@@ -13,7 +13,7 @@ import { ERC20Artifact, ERC20Contract } from "./typings/bindings/erc20";
 import { RenTokenArtifact, RenTokenContract } from "./typings/bindings/ren_token";
 import { SelfDestructingTokenArtifact } from "./typings/bindings/self_destructing_token";
 
-import { DARKNODE_PAYMENT_CYCLE_DURATION } from "../migrations/config";
+import { DARKNODE_PAYMENT_CYCLE_DURATION_SECS } from "../migrations/config";
 
 const CycleChanger = artifacts.require("CycleChanger") as CycleChangerArtifact;
 const RenToken = artifacts.require("RenToken") as RenTokenArtifact;
@@ -25,8 +25,6 @@ const SelfDestructingToken = artifacts.require("SelfDestructingToken") as SelfDe
 
 const hour = 60 * 60;
 const day = 24 * hour;
-
-const CYCLE_DURATION = DARKNODE_PAYMENT_CYCLE_DURATION * day;
 
 contract("DarknodePayment", (accounts: string[]) => {
 
@@ -529,7 +527,7 @@ contract("DarknodePayment", (accounts: string[]) => {
     describe("Changing cycles", async () => {
 
         it("cannot change cycle if insufficient time has passed", async () => {
-            await waitForCycle(CYCLE_DURATION / 2);
+            await waitForCycle(DARKNODE_PAYMENT_CYCLE_DURATION_SECS / 2);
             await dnp.changeCycle().should.eventually.be.rejectedWith(null, /cannot cycle yet: too early/);
         });
 
@@ -547,7 +545,7 @@ contract("DarknodePayment", (accounts: string[]) => {
             await changeCycleDuration(0);
             await cc.changeCycle().should.eventually.be.rejectedWith(null, /no new block/);
             // Reset the duration back to normal
-            await changeCycleDuration(DARKNODE_PAYMENT_CYCLE_DURATION);
+            await changeCycleDuration(DARKNODE_PAYMENT_CYCLE_DURATION_SECS);
         });
 
     });

--- a/test-ts/DarknodePayment.ts
+++ b/test-ts/DarknodePayment.ts
@@ -162,9 +162,12 @@ contract("DarknodePayment", (accounts: string[]) => {
         });
 
         it("properly sets index", async () => {
-            const one = "1".repeat(40);
-            const two = "2".repeat(40);
-            const three = "3".repeat(40);
+            const token1 = await ERC20.new();
+            const token2 = await ERC20.new();
+            const token3 = await ERC20.new();
+            const one = token1.address;
+            const two = token2.address;
+            const three = token3.address;
 
             await checkTokenIndexes();
             await dnp.registerToken(one);

--- a/test-ts/DarknodePayment.ts
+++ b/test-ts/DarknodePayment.ts
@@ -127,7 +127,7 @@ contract("DarknodePayment", (accounts: string[]) => {
             await checkTokenIndexes();
         });
 
-        it.skip("can deregister a destroyed token", async () => {
+        it("can deregister a destroyed token", async () => {
             // Claim so that the darknode share count isn't 0.
             await dnp.claim(darknode6);
             const sdt = await SelfDestructingToken.new();

--- a/test-ts/DarknodePayment.ts
+++ b/test-ts/DarknodePayment.ts
@@ -531,8 +531,7 @@ contract("DarknodePayment", (accounts: string[]) => {
     describe("Changing cycles", async () => {
 
         it("cannot change cycle if insufficient time has passed", async () => {
-            await waitForCycle(DARKNODE_PAYMENT_CYCLE_DURATION_SECS / 2);
-            await dnp.changeCycle().should.eventually.be.rejectedWith(null, /cannot cycle yet: too early/);
+            await waitForCycle(DARKNODE_PAYMENT_CYCLE_DURATION_SECS / 2).should.eventually.be.rejectedWith(null, /cannot cycle yet: too early/);
         });
 
         it("should disallow unauthorized changes to cycle duration", async () => {

--- a/test-ts/DarknodePayment.ts
+++ b/test-ts/DarknodePayment.ts
@@ -148,8 +148,8 @@ contract("DarknodePayment", (accounts: string[]) => {
 
         it("can deregister tokens", async () => {
             await dnp.deregisterToken(ETHEREUM_TOKEN_ADDRESS);
-            await dnp.deregisterToken(ETHEREUM_TOKEN_ADDRESS).should.be.rejectedWith(null, /token already pending deregistration/);
-            await dnp.deregisterToken(erc20Token.address).should.not.be.rejectedWith(null, /token already pending deregistration/);
+            await dnp.deregisterToken(ETHEREUM_TOKEN_ADDRESS).should.be.rejectedWith(null, /token not registered/);
+            await dnp.deregisterToken(erc20Token.address).should.not.be.rejectedWith(null, /token not registered/);
             // complete token deregistration
             await waitForCycle();
             (await dnp.registeredTokenIndex(ETHEREUM_TOKEN_ADDRESS)).should.bignumber.equal(0);

--- a/test-ts/DarknodePayment.ts
+++ b/test-ts/DarknodePayment.ts
@@ -136,6 +136,7 @@ contract("DarknodePayment", (accounts: string[]) => {
             await sdt.destruct();
             await dnp.deregisterToken(sdt.address);
             await waitForCycle();
+            await dnp.blacklist(darknode6);
         });
 
         it("cannot register already registered tokens", async () => {

--- a/truffle.js
+++ b/truffle.js
@@ -8,7 +8,7 @@ module.exports = {
   networks: {
     kovan: {
       // @ts-ignore
-      provider: new HDWalletProvider(process.env.MNEMONIC, `https://kovan.infura.io/v3/${process.env.INFURA_KEY}`),
+      provider: () => new HDWalletProvider(process.env.MNEMONIC, `https://kovan.infura.io/v3/${process.env.INFURA_KEY}`),
       network_id: 42,
       gas: 6721975,
       gasPrice: 10 * GWEI,


### PR DESCRIPTION
**Description**

This PR changes the cycle definition to be in seconds rather than days, and also immediately deregisters tokens rather than waiting for pending and updating the token list at cycle change.

Additionally this PR also fixes failing tests and `npm` and `yarn` inconsistencies in the `README.md` and `package.json`

**Motivation**

By defining the cycle in seconds, we can have more flexibility in cycle times. We could for example have 10 minute cycle times etc.

If we have registered a self-destructing token, attempts to call `claim()` and `changeCycle()` will fail and revert. By deregistering tokens immediately, we can remove broken tokens causing functions to revert.

**Design**

Since tokens are deregistered immediately, it can mean that during any particular cycle, darknode A could earn more rewards than darknode B simply because they claimed and withdrew their rewards before the token was deregistered. This situation should not occur too often since tokens will not be deregistered often. This can also be mitigated by deregistering a token as close to the change in cycle as possible.
