### PR TITLE
Fix updating cycle duration to be in seconds

### DIFF
--- a/contracts/DarknodePayment/DarknodePayment.sol
+++ b/contracts/DarknodePayment/DarknodePayment.sol
@@ -312,10 +312,11 @@ contract DarknodePayment is Ownable {
 
     /// @notice Updates cycle duration
     ///
-    /// @param _duration The time before a new cycle can be called, in days
-    function updateCycleDuration(uint256 _duration) external onlyOwner {
+    /// @param _durationSecs The amount of time (in seconds) that should have
+    ///        passed before a new cycle can be called.
+    function updateCycleDuration(uint256 _durationSecs) external onlyOwner {
         uint256 oldDuration = cycleDuration;
-        cycleDuration = _duration.mul(1 days);
+        cycleDuration = _durationSecs;
         emit LogCycleDurationChanged(cycleDuration, oldDuration);
     }
 

--- a/test-ts/DarknodePayment.ts
+++ b/test-ts/DarknodePayment.ts
@@ -567,7 +567,7 @@ contract("DarknodePayment", (accounts: string[]) => {
 
         it("can change cycle duration", async () => {
             // Set the duration to 3 days
-            await changeCycleDuration(3);
+            await changeCycleDuration(3 * day);
         });
 
         it("should error when block number has not changed", async () => {
@@ -711,12 +711,10 @@ contract("DarknodePayment", (accounts: string[]) => {
         (await dnp.currentCycleRewardPool(dai.address)).should.bignumber.equal(previousBalance.add(amountBN));
     }
 
-    const changeCycleDuration = async (timeInDays: number) => {
-        const timeInSecs = timeInDays * day;
+    const changeCycleDuration = async (timeInSecs: number) => {
         const currentCycleDurationInSecs = new BN(await dnp.cycleDuration()).toNumber();
-        // console.log(currentCycleDurationInSecs.toString());
 
-        await dnp.updateCycleDuration(timeInDays);
+        await dnp.updateCycleDuration(timeInSecs);
         (await dnp.cycleDuration()).should.bignumber.equal(timeInSecs);
 
         // put into effect the new cycle duration

--- a/test-ts/DarknodePayment.ts
+++ b/test-ts/DarknodePayment.ts
@@ -558,7 +558,7 @@ contract("DarknodePayment", (accounts: string[]) => {
     describe("Changing cycles", async () => {
 
         it("cannot change cycle if insufficient time has passed", async () => {
-            await waitForCycle(DARKNODE_PAYMENT_CYCLE_DURATION_SECS / 2).should.eventually.be.rejectedWith(null, /cannot cycle yet: too early/);
+            await waitForCycle(DARKNODE_PAYMENT_CYCLE_DURATION_SECS / 4).should.eventually.be.rejectedWith(null, /cannot cycle yet: too early/);
         });
 
         it("should disallow unauthorized changes to cycle duration", async () => {


### PR DESCRIPTION
After #46, cycle durations should be defined in seconds. The `updateCycleDuration()` function was not updated for this and still used days. This PR fixes that issue.