### PR TITLE
Fix chai-bignumber dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bn.js": "^4.11.8",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "chai-bignumber": "git://github.com/negaex/chai-bignumber.git#master",
+    "chai-bignumber": "git://github.com/noiach/chai-bignumber.git#master",
     "coveralls": "^3.0.3",
     "crypto-js": "^3.1.9-1",
     "dotenv": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,7 +636,7 @@ chai-as-promised@^7.1.1:
 
 "chai-bignumber@git://github.com/negaex/chai-bignumber.git#master":
   version "2.0.2"
-  resolved "git://github.com/negaex/chai-bignumber.git#362c82ce6a7c10f458a8cf0e1f09ca5d36b9b52a"
+  resolved "git://github.com/negaex/chai-bignumber.git#fd75e47b2980c3a151d2a05b070293b18a9bddce"
 
 chai@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,9 +634,9 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
-"chai-bignumber@git://github.com/negaex/chai-bignumber.git#master":
+"chai-bignumber@git://github.com/noiach/chai-bignumber.git#master":
   version "2.0.2"
-  resolved "git://github.com/negaex/chai-bignumber.git#fd75e47b2980c3a151d2a05b070293b18a9bddce"
+  resolved "git://github.com/noiach/chai-bignumber.git#fd75e47b2980c3a151d2a05b070293b18a9bddce"
 
 chai@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Fixed the `yarn.lock` so it can find the correct chai-bignumber fork.