### PR TITLE
RenERC20 rate to support continuous fees

### DIFF
--- a/contracts/Bindings.sol
+++ b/contracts/Bindings.sol
@@ -8,7 +8,7 @@ import "./DarknodeSlasher/DarknodeSlasher.sol";
 import "./RenToken/RenToken.sol";
 import "./Gateway/Gateway.sol";
 import "./Gateway/GatewayRegistry.sol";
-import "./Protocol/ProtocolLogic.sol";
+import "./Protocol/Protocol.sol";
 
 /// @notice Bindings imports all of the contracts for generating bindings.
 /* solium-disable-next-line no-empty-blocks */

--- a/contracts/Gateway/ERC20WithRate.sol
+++ b/contracts/Gateway/ERC20WithRate.sol
@@ -44,14 +44,14 @@ contract ERC20WithRate is Initializable, Ownable, ERC20 {
         view
         returns (uint256)
     {
-        return multiplyByRate(balanceOf(_account));
+        return toUnderlying(balanceOf(_account));
     }
 
-    function multiplyByRate(uint256 _value) public view returns (uint256) {
+    function toUnderlying(uint256 _value) public view returns (uint256) {
         return _value.mul(_rate).div(_rateScale);
     }
 
-    function divideByRate(uint256 _value) public view returns (uint256) {
+    function fromUnderlying(uint256 _value) public view returns (uint256) {
         return _value.mul(_rateScale).div(_rate);
     }
 }

--- a/contracts/Gateway/ERC20WithRate.sol
+++ b/contracts/Gateway/ERC20WithRate.sol
@@ -47,11 +47,15 @@ contract ERC20WithRate is Initializable, Ownable, ERC20 {
         return toUnderlying(balanceOf(_account));
     }
 
-    function toUnderlying(uint256 _value) public view returns (uint256) {
-        return _value.mul(_rate).div(_rateScale);
+    function toUnderlying(uint256 _amount) public view returns (uint256) {
+        return _amount.mul(_rate).div(_rateScale);
     }
 
-    function fromUnderlying(uint256 _value) public view returns (uint256) {
-        return _value.mul(_rateScale).div(_rate);
+    function fromUnderlying(uint256 _amountUnderlying)
+        public
+        view
+        returns (uint256)
+    {
+        return _amountUnderlying.mul(_rateScale).div(_rate);
     }
 }

--- a/contracts/Gateway/ERC20WithRate.sol
+++ b/contracts/Gateway/ERC20WithRate.sol
@@ -1,0 +1,57 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/upgrades/contracts/Initializable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+
+/// @notice RenERC20 represents a digital asset that has been bridged on to
+/// the Ethereum ledger. It exposes mint and burn functions that can only be
+/// called by it's associated Gateway contract.
+contract ERC20WithRate is Initializable, Ownable, ERC20 {
+    using SafeMath for uint256;
+
+    uint256 public constant _rateScale = 1e18;
+    uint256 internal _rate;
+
+    event LogRateChanged(uint256 indexed _rate);
+
+    /* solium-disable-next-line no-empty-blocks */
+    function initialize(address _nextOwner, uint256 _initialRate)
+        public
+        initializer
+    {
+        Ownable.initialize(_nextOwner);
+        _setRate(_initialRate);
+    }
+
+    function setExchangeRate(uint256 _nextRate) public onlyOwner {
+        _setRate(_nextRate);
+    }
+
+    function exchangeRateCurrent() public view returns (uint256) {
+        require(_rate != 0, "ERC20WithRate: rate has not been initialized");
+        return _rate;
+    }
+
+    function _setRate(uint256 _nextRate) internal {
+        require(_nextRate > 0, "ERC20WithRate: rate must be greater than zero");
+        _rate = _nextRate;
+    }
+
+    function balanceOfUnderlying(address _account)
+        public
+        view
+        returns (uint256)
+    {
+        return multiplyByRate(balanceOf(_account));
+    }
+
+    function multiplyByRate(uint256 _value) public view returns (uint256) {
+        return _value.mul(_rate).div(_rateScale);
+    }
+
+    function divideByRate(uint256 _value) public view returns (uint256) {
+        return _value.mul(_rateScale).div(_rate);
+    }
+}

--- a/contracts/Gateway/Gateway.sol
+++ b/contracts/Gateway/Gateway.sol
@@ -193,7 +193,7 @@ contract Gateway is IGateway, Claimable, CanReclaimTokens {
         }
         status[signedMessageHash] = true;
 
-        uint256 amountScaled = token.divideByRate(_amount);
+        uint256 amountScaled = token.fromUnderlying(_amount);
 
         // Mint `amount - fee` for the recipient and mint `fee` for the minter
         uint256 absoluteFeeScaled = amountScaled.mul(mintFee).div(
@@ -205,7 +205,7 @@ contract Gateway is IGateway, Claimable, CanReclaimTokens {
 
         // Emit a log with a unique identifier 'n'.
         // Use underlying amount, not scaled by rate.
-        uint256 receivedAmount = token.multiplyByRate(receivedAmountScaled);
+        uint256 receivedAmount = token.toUnderlying(receivedAmountScaled);
         emit LogMint(msg.sender, receivedAmount, nextN, signedMessageHash);
         nextN += 1;
 
@@ -216,7 +216,7 @@ contract Gateway is IGateway, Claimable, CanReclaimTokens {
         public
         returns (uint256)
     {
-        return burn(_to, token.divideByRate(_amountScaled));
+        return burn(_to, token.toUnderlying(_amountScaled));
     }
 
     /// @notice burn destroys tokens after taking a fee for the `_feeRecipient`,
@@ -239,9 +239,9 @@ contract Gateway is IGateway, Claimable, CanReclaimTokens {
 
         // Burn full amount and mint fee
         uint256 absoluteFee = _amount.mul(burnFee).div(BIPS_DENOMINATOR);
-        uint256 amountScaled = token.divideByRate(_amount);
-        uint256 receivedScaled = token.divideByRate(_amount.sub(absoluteFee));
-        uint256 receivedValue = token.multiplyByRate(receivedScaled);
+        uint256 amountScaled = token.fromUnderlying(_amount);
+        uint256 receivedScaled = token.fromUnderlying(_amount.sub(absoluteFee));
+        uint256 receivedValue = token.toUnderlying(receivedScaled);
         uint256 amountDifference = amountScaled.sub(receivedScaled);
         token.burn(msg.sender, amountScaled);
         token.mint(feeRecipient, amountDifference);

--- a/contracts/Gateway/Gateway.sol
+++ b/contracts/Gateway/Gateway.sol
@@ -152,21 +152,21 @@ contract Gateway is IGateway, Claimable, CanReclaimTokens {
     ///
     /// @param _pHash (payload hash) The hash of the payload associated with the
     ///        mint.
-    /// @param _amount The amount of the token being minted, in its smallest
+    /// @param _amountUnderlying The amount of the token being minted, in its smallest
     ///        value. (e.g. satoshis for BTC).
     /// @param _nHash (nonce hash) The hash of the nonce, amount and pHash.
     /// @param _sig The signature of the hash of the following values:
     ///        (pHash, amount, msg.sender, nHash), signed by the mintAuthority.
     function mint(
         bytes32 _pHash,
-        uint256 _amount,
+        uint256 _amountUnderlying,
         bytes32 _nHash,
         bytes memory _sig
     ) public returns (uint256) {
         // Verify signature
         bytes32 signedMessageHash = hashForSignature(
             _pHash,
-            _amount,
+            _amountUnderlying,
             msg.sender,
             _nHash
         );
@@ -183,7 +183,7 @@ contract Gateway is IGateway, Claimable, CanReclaimTokens {
                     "Gateway: invalid signature. pHash: ",
                     String.fromBytes32(_pHash),
                     ", amount: ",
-                    String.fromUint(_amount),
+                    String.fromUint(_amountUnderlying),
                     ", msg.sender: ",
                     String.fromAddress(msg.sender),
                     ", _nHash: ",
@@ -193,30 +193,35 @@ contract Gateway is IGateway, Claimable, CanReclaimTokens {
         }
         status[signedMessageHash] = true;
 
-        uint256 amountScaled = token.fromUnderlying(_amount);
+        uint256 amountScaled = token.fromUnderlying(_amountUnderlying);
 
         // Mint `amount - fee` for the recipient and mint `fee` for the minter
         uint256 absoluteFeeScaled = amountScaled.mul(mintFee).div(
             BIPS_DENOMINATOR
         );
-        uint256 receivedAmountScaled = amountScaled.sub(absoluteFeeScaled);
+        uint256 receivedAmountScaled = amountScaled.sub(
+            absoluteFeeScaled,
+            "Gateway: fee exceeds amount"
+        );
+
+        // Mint amount minus the fee
         token.mint(msg.sender, receivedAmountScaled);
+        // Mint the fee
         token.mint(feeRecipient, absoluteFeeScaled);
 
         // Emit a log with a unique identifier 'n'.
-        // Use underlying amount, not scaled by rate.
-        uint256 receivedAmount = token.toUnderlying(receivedAmountScaled);
-        emit LogMint(msg.sender, receivedAmount, nextN, signedMessageHash);
+        uint256 receivedAmountUnderlying = token.toUnderlying(
+            receivedAmountScaled
+        );
+        emit LogMint(
+            msg.sender,
+            receivedAmountUnderlying,
+            nextN,
+            signedMessageHash
+        );
         nextN += 1;
 
         return receivedAmountScaled;
-    }
-
-    function burn(bytes memory _to, uint256 _amountScaled)
-        public
-        returns (uint256)
-    {
-        return burn(_to, token.toUnderlying(_amountScaled));
     }
 
     /// @notice burn destroys tokens after taking a fee for the `_feeRecipient`,
@@ -229,34 +234,46 @@ contract Gateway is IGateway, Claimable, CanReclaimTokens {
     ///        Bitcoin address.
     /// @param _amount The amount of the token being burnt, in its
     ///        smallest value. (e.g. satoshis for BTC)
-    function burnUnderlying(bytes memory _to, uint256 _amount)
-        public
-        returns (uint256)
-    {
+    function burn(bytes memory _to, uint256 _amount) public returns (uint256) {
         // The recipient must not be empty. Better validation is possible,
         // but would need to be customized for each destination ledger.
         require(_to.length != 0, "Gateway: to address is empty");
 
-        // Burn full amount and mint fee
-        uint256 absoluteFee = _amount.mul(burnFee).div(BIPS_DENOMINATOR);
-        uint256 amountScaled = token.fromUnderlying(_amount);
-        uint256 receivedScaled = token.fromUnderlying(_amount.sub(absoluteFee));
-        uint256 receivedValue = token.toUnderlying(receivedScaled);
-        uint256 amountDifference = amountScaled.sub(receivedScaled);
-        token.burn(msg.sender, amountScaled);
-        token.mint(feeRecipient, amountDifference);
+        // Calculate fee, subtract it from amount being burnt.
+        uint256 fee = _amount.mul(burnFee).div(BIPS_DENOMINATOR);
+        uint256 amountAfterFee = _amount.sub(
+            fee,
+            "Gateway: fee exceeds amount"
+        );
+
+        // If the underlying token has a higher precision, adjust the scaled
+        // amount so that only representable values are burnt.
+        uint256 amountAfterFeeUnderlying = token.toUnderlying(amountAfterFee);
+        uint256 amountAfterFeeRepresentable = token.fromUnderlying(
+            amountAfterFeeUnderlying
+        );
+
+        // The amount being burnt is the sum of the representable amount and the
+        // fee.
+        uint256 burnAmount = amountAfterFeeRepresentable.add(fee);
+        assert(burnAmount <= _amount);
+
+        // Burn the whole amount, and then re-mint the fee.
+
+        token.burn(msg.sender, burnAmount);
+        token.mint(feeRecipient, fee);
 
         require(
             // Must be strictly greater, to that the release transaction is of
             // at least one unit.
-            receivedValue > minimumBurnAmount,
+            amountAfterFeeUnderlying > minimumBurnAmount,
             "Gateway: amount is less than the minimum burn amount"
         );
 
-        emit LogBurn(_to, receivedValue, nextN, _to);
+        emit LogBurn(_to, amountAfterFeeUnderlying, nextN, _to);
         nextN += 1;
 
-        return receivedScaled;
+        return amountAfterFeeUnderlying;
     }
 
     /// @notice verifySignature checks the the provided signature matches the provided

--- a/contracts/Gateway/RenERC20.sol
+++ b/contracts/Gateway/RenERC20.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Deta
 
 import "../libraries/Claimable.sol";
 import "../libraries/CanReclaimTokens.sol";
+import "./ERC20WithRate.sol";
 
 /// @notice RenERC20 represents a digital asset that has been bridged on to
 /// the Ethereum ledger. It exposes mint and burn functions that can only be
@@ -16,17 +17,20 @@ contract RenERC20 is
     Initializable,
     ERC20,
     ERC20Detailed,
+    ERC20WithRate,
     Claimable,
     CanReclaimTokens
 {
     /* solium-disable-next-line no-empty-blocks */
     function initialize(
         address _nextOwner,
+        uint256 _initialRate,
         string memory _name,
         string memory _symbol,
         uint8 _decimals
     ) public initializer {
         ERC20Detailed.initialize(_name, _symbol, _decimals);
+        ERC20WithRate.initialize(_nextOwner, _initialRate);
         Claimable.initialize(_nextOwner);
         CanReclaimTokens.initialize(_nextOwner);
     }

--- a/contracts/Gateway/adapters/BasicAdapter.sol
+++ b/contracts/Gateway/adapters/BasicAdapter.sol
@@ -43,7 +43,7 @@ contract BasicAdapter is GSNRecipient {
             ),
             "token transfer failed"
         );
-        registry.getGatewayBySymbol(_symbol).burnUnderlying(_to, _amount);
+        registry.getGatewayBySymbol(_symbol).burn(_to, _amount);
     }
 
     // GSN functions

--- a/contracts/Gateway/adapters/BasicAdapter.sol
+++ b/contracts/Gateway/adapters/BasicAdapter.sol
@@ -2,8 +2,8 @@ pragma solidity 0.5.16;
 
 import "@openzeppelin/contracts-ethereum-package/contracts/GSN/GSNRecipient.sol";
 
-import "../IGateway.sol";
-import "../IGatewayRegistry.sol";
+import "../interfaces/IGateway.sol";
+import "../interfaces/IGatewayRegistry.sol";
 
 contract BasicAdapter is GSNRecipient {
     IGatewayRegistry registry;
@@ -43,7 +43,7 @@ contract BasicAdapter is GSNRecipient {
             ),
             "token transfer failed"
         );
-        registry.getGatewayBySymbol(_symbol).burn(_to, _amount);
+        registry.getGatewayBySymbol(_symbol).burnUnderlying(_to, _amount);
     }
 
     // GSN functions

--- a/contracts/Gateway/examples/Vesting.sol
+++ b/contracts/Gateway/examples/Vesting.sol
@@ -108,10 +108,7 @@ contract Vesting is Ownable {
         // Burn the tokens using the Gateway contract. This will burn the
         // tokens after taking a fee. The Darknodes will watch for this event to
         // transfer the user the Bitcoin.
-        registry.getGatewayBySymbol("renBTC").burnUnderlying(
-            _to,
-            amountClaimable
-        );
+        registry.getGatewayBySymbol("BTC").burn(_to, amountClaimable);
     }
 
     /// @notice Retrieves the claimable amount for a given beneficiary.

--- a/contracts/Gateway/examples/Vesting.sol
+++ b/contracts/Gateway/examples/Vesting.sol
@@ -70,7 +70,7 @@ contract Vesting is Ownable {
         bytes32 pHash = keccak256(
             abi.encode(_beneficiary, _startTime, _duration)
         );
-        uint256 finalAmount = registry.getGatewayBySymbol("renBTC").mint(
+        uint256 finalAmountScaled = registry.getGatewayBySymbol("renBTC").mint(
             pHash,
             _amount,
             _nHash,
@@ -81,7 +81,7 @@ contract Vesting is Ownable {
         VestingSchedule memory schedule = VestingSchedule({
             startTime: _startTime == 0 ? now : _startTime,
             duration: _duration,
-            amount: finalAmount,
+            amount: finalAmountScaled,
             monthsClaimed: 0,
             amountClaimed: 0
         });
@@ -108,7 +108,10 @@ contract Vesting is Ownable {
         // Burn the tokens using the Gateway contract. This will burn the
         // tokens after taking a fee. The Darknodes will watch for this event to
         // transfer the user the Bitcoin.
-        registry.getGatewayBySymbol("renBTC").burn(_to, amountClaimable);
+        registry.getGatewayBySymbol("renBTC").burnUnderlying(
+            _to,
+            amountClaimable
+        );
     }
 
     /// @notice Retrieves the claimable amount for a given beneficiary.

--- a/contracts/Gateway/interfaces/IGateway.sol
+++ b/contracts/Gateway/interfaces/IGateway.sol
@@ -14,9 +14,6 @@ interface IBurnGateway {
     function burn(bytes calldata _to, uint256 _amountScaled)
         external
         returns (uint256);
-    function burnUnderlying(bytes calldata _to, uint256 _amount)
-        external
-        returns (uint256);
     function burnFee() external view returns (uint256);
 }
 
@@ -32,9 +29,6 @@ interface IGateway {
     function mintFee() external view returns (uint256);
     // is IBurnGateway
     function burn(bytes calldata _to, uint256 _amountScaled)
-        external
-        returns (uint256);
-    function burnUnderlying(bytes calldata _to, uint256 _amount)
         external
         returns (uint256);
     function burnFee() external view returns (uint256);

--- a/contracts/Gateway/interfaces/IGateway.sol
+++ b/contracts/Gateway/interfaces/IGateway.sol
@@ -11,7 +11,10 @@ interface IMintGateway {
 }
 
 interface IBurnGateway {
-    function burn(bytes calldata _to, uint256 _amount)
+    function burn(bytes calldata _to, uint256 _amountScaled)
+        external
+        returns (uint256);
+    function burnUnderlying(bytes calldata _to, uint256 _amount)
         external
         returns (uint256);
     function burnFee() external view returns (uint256);
@@ -28,7 +31,10 @@ interface IGateway {
     ) external returns (uint256);
     function mintFee() external view returns (uint256);
     // is IBurnGateway
-    function burn(bytes calldata _to, uint256 _amount)
+    function burn(bytes calldata _to, uint256 _amountScaled)
+        external
+        returns (uint256);
+    function burnUnderlying(bytes calldata _to, uint256 _amount)
         external
         returns (uint256);
     function burnFee() external view returns (uint256);

--- a/contracts/Gateway/interfaces/IGatewayRegistry.sol
+++ b/contracts/Gateway/interfaces/IGatewayRegistry.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.5.16;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/IERC20.sol";
 
 import "./IGateway.sol";
 
@@ -31,13 +31,13 @@ interface IGatewayRegistry {
     function getGateways(address _start, uint256 _count)
         external
         view
-        returns (IGateway[] memory);
+        returns (address[] memory);
 
     /// @dev To get all the registered RenERC20s use count = 0.
     function getRenTokens(address _start, uint256 _count)
         external
         view
-        returns (IERC20[] memory);
+        returns (address[] memory);
 
     /// @notice Returns the Gateway contract for the given RenERC20
     ///         address.


### PR DESCRIPTION
This PR updated RenERC20 tokens to track a rate which dictates the ratio of tokens to the native asset they represent. This allows for continuous fees to be charged by updating this rate, without modifying the ERC20 balances on-chain.