### PR TITLE
RenERC20 permit method for approving with signatures

### DIFF
--- a/contracts/Gateway/ERC20WithPermit.sol
+++ b/contracts/Gateway/ERC20WithPermit.sol
@@ -1,0 +1,82 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/upgrades/contracts/Initializable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol";
+
+/// @notice Taken from the DAI token.
+contract ERC20WithRate is Initializable, ERC20, ERC20Detailed {
+    using SafeMath for uint256;
+
+    mapping(address => uint256) public nonces;
+
+    // --- EIP712 niceties ---
+    bytes32 public DOMAIN_SEPARATOR;
+    // PERMIT_TYPEHASH is the value returned from
+    // keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)")
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+
+    function initialize(
+        uint256 chainId_,
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    ) public initializer {
+        ERC20Detailed.initialize(_name, _symbol, _decimals);
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes(name())),
+                chainId_,
+                address(this)
+            )
+        );
+    }
+
+    // --- Approve by signature ---
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(
+                    abi.encode(
+                        PERMIT_TYPEHASH,
+                        holder,
+                        spender,
+                        nonce,
+                        expiry,
+                        allowed
+                    )
+                )
+            )
+        );
+
+        require(holder != address(0), "ERC20WithRate: address must not be 0x0");
+        require(
+            holder == ecrecover(digest, v, r, s),
+            "ERC20WithRate: invalid signature"
+        );
+        require(
+            expiry == 0 || now <= expiry,
+            "ERC20WithRate: permit has expired"
+        );
+        require(nonce == nonces[holder]++, "ERC20WithRate: invalid nonce");
+        uint256 amount = allowed ? uint256(-1) : 0;
+        _approve(holder, spender, amount);
+        emit Approval(holder, spender, amount);
+    }
+}

--- a/contracts/Gateway/ERC20WithPermit.sol
+++ b/contracts/Gateway/ERC20WithPermit.sol
@@ -12,6 +12,10 @@ contract ERC20WithPermit is Initializable, ERC20, ERC20Detailed {
 
     mapping(address => uint256) public nonces;
 
+    // If the token is redeployed, the version is increased to prevent a permit
+    // signature being used on both token instances.
+    string public version;
+
     // --- EIP712 niceties ---
     bytes32 public DOMAIN_SEPARATOR;
     // PERMIT_TYPEHASH is the value returned from
@@ -19,19 +23,22 @@ contract ERC20WithPermit is Initializable, ERC20, ERC20Detailed {
     bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
 
     function initialize(
-        uint256 chainId_,
+        uint256 _chainId,
+        string memory _version,
         string memory _name,
         string memory _symbol,
         uint8 _decimals
     ) public initializer {
         ERC20Detailed.initialize(_name, _symbol, _decimals);
+        version = _version;
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
                 keccak256(
-                    "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
                 ),
                 keccak256(bytes(name())),
-                chainId_,
+                keccak256(bytes(version)),
+                _chainId,
                 address(this)
             )
         );

--- a/contracts/Gateway/ERC20WithPermit.sol
+++ b/contracts/Gateway/ERC20WithPermit.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol";
 
 /// @notice Taken from the DAI token.
-contract ERC20WithRate is Initializable, ERC20, ERC20Detailed {
+contract ERC20WithPermit is Initializable, ERC20, ERC20Detailed {
     using SafeMath for uint256;
 
     mapping(address => uint256) public nonces;

--- a/contracts/Gateway/RenERC20.sol
+++ b/contracts/Gateway/RenERC20.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Deta
 import "../libraries/Claimable.sol";
 import "../libraries/CanReclaimTokens.sol";
 import "./ERC20WithRate.sol";
+import "./ERC20WithPermit.sol";
 
 /// @notice RenERC20 represents a digital asset that has been bridged on to
 /// the Ethereum ledger. It exposes mint and burn functions that can only be
@@ -18,11 +19,13 @@ contract RenERC20 is
     ERC20,
     ERC20Detailed,
     ERC20WithRate,
+    ERC20WithPermit,
     Claimable,
     CanReclaimTokens
 {
     /* solium-disable-next-line no-empty-blocks */
     function initialize(
+        uint256 _chainId,
         address _nextOwner,
         uint256 _initialRate,
         string memory _name,
@@ -31,6 +34,7 @@ contract RenERC20 is
     ) public initializer {
         ERC20Detailed.initialize(_name, _symbol, _decimals);
         ERC20WithRate.initialize(_nextOwner, _initialRate);
+        ERC20WithPermit.initialize(_chainId, _name, _symbol, _decimals);
         Claimable.initialize(_nextOwner);
         CanReclaimTokens.initialize(_nextOwner);
     }

--- a/contracts/Gateway/RenERC20.sol
+++ b/contracts/Gateway/RenERC20.sol
@@ -28,13 +28,20 @@ contract RenERC20 is
         uint256 _chainId,
         address _nextOwner,
         uint256 _initialRate,
+        string memory _version,
         string memory _name,
         string memory _symbol,
         uint8 _decimals
     ) public initializer {
         ERC20Detailed.initialize(_name, _symbol, _decimals);
         ERC20WithRate.initialize(_nextOwner, _initialRate);
-        ERC20WithPermit.initialize(_chainId, _name, _symbol, _decimals);
+        ERC20WithPermit.initialize(
+            _chainId,
+            _version,
+            _name,
+            _symbol,
+            _decimals
+        );
         Claimable.initialize(_nextOwner);
         CanReclaimTokens.initialize(_nextOwner);
     }


### PR DESCRIPTION
This PR introduces the method `permit` to the RenERC20 token contract, allowing a user to approve their tokens to be spent without needing to spend any ETH.

Note that this only supports approving the entire user's token balance.