### PR TITLE
Look up Gateways by "BTC" instead of "renBTC" or "testBTC"

### DIFF
--- a/contracts/Gateway/examples/Vesting.sol
+++ b/contracts/Gateway/examples/Vesting.sol
@@ -70,7 +70,7 @@ contract Vesting is Ownable {
         bytes32 pHash = keccak256(
             abi.encode(_beneficiary, _startTime, _duration)
         );
-        uint256 finalAmountScaled = registry.getGatewayBySymbol("renBTC").mint(
+        uint256 finalAmountScaled = registry.getGatewayBySymbol("BTC").mint(
             pHash,
             _amount,
             _nHash,
@@ -108,10 +108,7 @@ contract Vesting is Ownable {
         // Burn the tokens using the Gateway contract. This will burn the
         // tokens after taking a fee. The Darknodes will watch for this event to
         // transfer the user the Bitcoin.
-        registry.getGatewayBySymbol("renBTC").burnUnderlying(
-            _to,
-            amountClaimable
-        );
+        registry.getGatewayBySymbol("BTC").burnUnderlying(_to, amountClaimable);
     }
 
     /// @notice Retrieves the claimable amount for a given beneficiary.

--- a/migrations/networks.js
+++ b/migrations/networks.js
@@ -15,6 +15,8 @@ const config = {
     renBTCMinimumBurnAmount: 10000,
     renZECMinimumBurnAmount: 10000,
     renBCHMinimumBurnAmount: 10000,
+
+    tokenPrefix: "mock",
 }
 
 module.exports = {
@@ -45,6 +47,8 @@ module.exports = {
             ...config,
             mintAuthority: "TODO",
             proxyGovernanceAddress: "0x5E2603499eddc325153d96445A6c44487F0d1859",
+
+            tokenPrefix: "ren",
         },
     },
     chaosnet: {
@@ -78,6 +82,8 @@ module.exports = {
             MINIMUM_BOND: new BN(10000).mul(new BN(10).pow(new BN(18))),
             mintAuthority: "0x5D0b91e8a8037C3EBB55f52D76BFc64CaBEBCAE1",
             proxyGovernanceAddress: "0x5E2603499eddc325153d96445A6c44487F0d1859",
+
+            tokenPrefix: "chaos",
         },
     },
     testnet: {
@@ -109,6 +115,8 @@ module.exports = {
             ...config,
             mintAuthority: "0x44Bb4eF43408072bC888Afd1a5986ba0Ce35Cb54",
             proxyGovernanceAddress: "0x5E2603499eddc325153d96445A6c44487F0d1859",
+
+            tokenPrefix: "test",
         },
     },
 
@@ -141,6 +149,8 @@ module.exports = {
             ...config,
             mintAuthority: "0x1B9d58208879AA9aa9E10040b34cF2b684237621",
             proxyGovernanceAddress: "0x5E2603499eddc325153d96445A6c44487F0d1859",
+
+            tokenPrefix: "dev",
         },
     },
 
@@ -173,6 +183,8 @@ module.exports = {
             ...config,
             mintAuthority: "0x04084f1cACCB87Dcab9a29a084281294dA96Bf44",
             proxyGovernanceAddress: "0x5E2603499eddc325153d96445A6c44487F0d1859",
+
+            tokenPrefix: "local",
         },
     },
 

--- a/test/Adapter.ts
+++ b/test/Adapter.ts
@@ -42,7 +42,7 @@ contract.skip("Adapter", ([owner, feeRecipient, user, proxyGovernanceAddress]) =
         );
 
         registry = await GatewayRegistry.new();
-        await registry.setGateway(renbtc.address, btcGateway.address);
+        await registry.setGateway("BTC", renbtc.address, btcGateway.address);
 
         await renbtc.transferOwnership(btcGateway.address);
         await btcGateway.claimTokenOwnership();
@@ -62,7 +62,7 @@ contract.skip("Adapter", ([owner, feeRecipient, user, proxyGovernanceAddress]) =
 
         const pHash = keccak256(web3.eth.abi.encodeParameters(
             ["string", "address"],
-            ["renBTC", user],
+            ["BTC", user],
         ));
 
         const hash = await btcGateway.hashForSignature.call(pHash, value, basicAdapter.address, nHash);
@@ -70,12 +70,12 @@ contract.skip("Adapter", ([owner, feeRecipient, user, proxyGovernanceAddress]) =
         const sigString = Ox(`${sig.r.toString("hex")}${sig.s.toString("hex")}${(sig.v).toString(16)}`);
 
         const balanceBeforeMint = new BN((await renbtc.balanceOfUnderlying.call(user)).toString());
-        await basicAdapter.mint("renBTC", user, value, nHash, sigString);
+        await basicAdapter.mint("BTC", user, value, nHash, sigString);
         const balanceAfterMint = new BN((await renbtc.balanceOfUnderlying.call(user)).toString());
         balanceAfterMint.should.bignumber.equal(balanceBeforeMint.add(burnValue));
 
         await renbtc.approve(basicAdapter.address, burnValue, { from: user });
-        await basicAdapter.burn("renBTC", bitcoinAddress, burnValue, { from: user });
+        await basicAdapter.burn("BTC", bitcoinAddress, burnValue, { from: user });
         (await renbtc.balanceOfUnderlying.call(user)).should.bignumber.equal(balanceAfterMint.sub(burnValue));
     });
 });

--- a/test/Protocol.ts
+++ b/test/Protocol.ts
@@ -159,10 +159,10 @@ contract("Protocol", ([owner, proxyGovernanceAddress, otherAccount]: string[]) =
         (await protocol.getGatewayByToken.call(renbtc.address))
             .should.equal(btcGateway.address);
 
-        (await protocol.getGatewayBySymbol.call("renBTC"))
+        (await protocol.getGatewayBySymbol.call("BTC"))
             .should.equal(btcGateway.address);
 
-        (await protocol.getTokenBySymbol.call("renBTC"))
+        (await protocol.getTokenBySymbol.call("BTC"))
             .should.equal(renbtc.address);
 
         { // The first 10 gateways starting from NULL

--- a/test/Vesting.ts
+++ b/test/Vesting.ts
@@ -43,7 +43,7 @@ contract.skip("Vesting", ([owner, feeRecipient, beneficiary, proxyGovernanceAddr
         await btcGateway.claimTokenOwnership();
 
         registry = await GatewayRegistry.new();
-        await registry.setGateway(renbtc.address, btcGateway.address);
+        await registry.setGateway("BTC", renbtc.address, btcGateway.address);
 
         // Setup the contracts for testing
         vesting = await Vesting.new(registry.address);


### PR DESCRIPTION
Currently, when registering a token and Gateway, the token's symbol is used as the key to look it up in the registry.

This PR allows a symbol to be provided when registering the token and Gateway, in place of the reading the token's symbol.

The provided symbol is a string restricted to `[A-Za-z0-9]*`. A string is used instead of an `enum` to allow for future tokens to be added easily.