### PR TITLE
 Add Timelock.sol

### DIFF
--- a/contracts/Governance/Timelock.sol
+++ b/contracts/Governance/Timelock.sol
@@ -11,6 +11,16 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 */
 
+/*
+
+Modification: INITIAL_MINIMUM_DELAY has been added to allow for initial set-up
+calls with a shorter delay. Once setDelay has been called for the first time,
+this no longer has any effect.
+
+INITIAL_MINIMUM_DELAY has been set to 0.
+
+*/
+
 pragma solidity 0.5.16;
 
 import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
@@ -47,6 +57,7 @@ contract Timelock {
     );
 
     uint256 public constant GRACE_PERIOD = 14 days;
+    uint256 public constant INITIAL_MINIMUM_DELAY = 0 days;
     uint256 public constant MINIMUM_DELAY = 2 days;
     uint256 public constant MAXIMUM_DELAY = 30 days;
 
@@ -58,8 +69,8 @@ contract Timelock {
 
     constructor(address admin_, uint256 delay_) public {
         require(
-            delay_ >= MINIMUM_DELAY,
-            "Timelock::constructor: Delay must exceed minimum delay."
+            delay_ >= INITIAL_MINIMUM_DELAY,
+            "Timelock::constructor: Delay must exceed initial minimum delay."
         );
         require(
             delay_ <= MAXIMUM_DELAY,

--- a/contracts/Governance/Timelock.sol
+++ b/contracts/Governance/Timelock.sol
@@ -1,0 +1,218 @@
+/*
+
+https://github.com/compound-finance/compound-protocol/blob/f244c2270f905287cb731d8fd3693ac77f8404f9/contracts/Timelock.sol
+https://blog.openzeppelin.com/compound-finance-patch-audit/
+
+The software and documentation available in this repository (the "Software") is protected by copyright law and accessible pursuant to the license set forth below. Copyright © 2019 Compound Labs, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person or organization obtaining the Software (the “Licensee”) to privately study, review, and analyze the Software. Licensee shall not use the Software for any other purpose. Licensee shall not modify, transfer, assign, share, or sub-license the Software or any derivative works of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE.
+
+*/
+
+pragma solidity 0.5.16;
+
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+
+contract Timelock {
+    using SafeMath for uint256;
+
+    event NewAdmin(address indexed newAdmin);
+    event NewPendingAdmin(address indexed newPendingAdmin);
+    event NewDelay(uint256 indexed newDelay);
+    event CancelTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+    event ExecuteTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+    event QueueTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+
+    uint256 public constant GRACE_PERIOD = 14 days;
+    uint256 public constant MINIMUM_DELAY = 2 days;
+    uint256 public constant MAXIMUM_DELAY = 30 days;
+
+    address public admin;
+    address public pendingAdmin;
+    uint256 public delay;
+
+    mapping(bytes32 => bool) public queuedTransactions;
+
+    constructor(address admin_, uint256 delay_) public {
+        require(
+            delay_ >= MINIMUM_DELAY,
+            "Timelock::constructor: Delay must exceed minimum delay."
+        );
+        require(
+            delay_ <= MAXIMUM_DELAY,
+            "Timelock::setDelay: Delay must not exceed maximum delay."
+        );
+
+        admin = admin_;
+        delay = delay_;
+    }
+
+    function() external payable {}
+
+    function setDelay(uint256 delay_) public {
+        require(
+            msg.sender == address(this),
+            "Timelock::setDelay: Call must come from Timelock."
+        );
+        require(
+            delay_ >= MINIMUM_DELAY,
+            "Timelock::setDelay: Delay must exceed minimum delay."
+        );
+        require(
+            delay_ <= MAXIMUM_DELAY,
+            "Timelock::setDelay: Delay must not exceed maximum delay."
+        );
+        delay = delay_;
+
+        emit NewDelay(delay);
+    }
+
+    function acceptAdmin() public {
+        require(
+            msg.sender == pendingAdmin,
+            "Timelock::acceptAdmin: Call must come from pendingAdmin."
+        );
+        admin = msg.sender;
+        pendingAdmin = address(0);
+
+        emit NewAdmin(admin);
+    }
+
+    function setPendingAdmin(address pendingAdmin_) public {
+        require(
+            msg.sender == address(this),
+            "Timelock::setPendingAdmin: Call must come from Timelock."
+        );
+        pendingAdmin = pendingAdmin_;
+
+        emit NewPendingAdmin(pendingAdmin);
+    }
+
+    function queueTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public returns (bytes32) {
+        require(
+            msg.sender == admin,
+            "Timelock::queueTransaction: Call must come from admin."
+        );
+        require(
+            eta >= getBlockTimestamp().add(delay),
+            "Timelock::queueTransaction: Estimated execution block must satisfy delay."
+        );
+
+        bytes32 txHash = keccak256(
+            abi.encode(target, value, signature, data, eta)
+        );
+        queuedTransactions[txHash] = true;
+
+        emit QueueTransaction(txHash, target, value, signature, data, eta);
+        return txHash;
+    }
+
+    function cancelTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public {
+        require(
+            msg.sender == admin,
+            "Timelock::cancelTransaction: Call must come from admin."
+        );
+
+        bytes32 txHash = keccak256(
+            abi.encode(target, value, signature, data, eta)
+        );
+        queuedTransactions[txHash] = false;
+
+        emit CancelTransaction(txHash, target, value, signature, data, eta);
+    }
+
+    function executeTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public payable returns (bytes memory) {
+        require(
+            msg.sender == admin,
+            "Timelock::executeTransaction: Call must come from admin."
+        );
+
+        bytes32 txHash = keccak256(
+            abi.encode(target, value, signature, data, eta)
+        );
+        require(
+            queuedTransactions[txHash],
+            "Timelock::executeTransaction: Transaction hasn't been queued."
+        );
+        require(
+            getBlockTimestamp() >= eta,
+            "Timelock::executeTransaction: Transaction hasn't surpassed time lock."
+        );
+        require(
+            getBlockTimestamp() <= eta.add(GRACE_PERIOD),
+            "Timelock::executeTransaction: Transaction is stale."
+        );
+
+        queuedTransactions[txHash] = false;
+
+        bytes memory callData;
+
+        if (bytes(signature).length == 0) {
+            callData = data;
+        } else {
+            callData = abi.encodePacked(
+                bytes4(keccak256(bytes(signature))),
+                data
+            );
+        }
+
+        // solium-disable-next-line security/no-call-value
+        (bool success, bytes memory returnData) = target.call.value(value)(
+            callData
+        );
+        require(
+            success,
+            "Timelock::executeTransaction: Transaction execution reverted."
+        );
+
+        emit ExecuteTransaction(txHash, target, value, signature, data, eta);
+
+        return returnData;
+    }
+
+    function getBlockTimestamp() internal view returns (uint256) {
+        // solium-disable-next-line security/no-block-members
+        return block.timestamp;
+    }
+}


### PR DESCRIPTION
This PR adds the [Compound Timelock contract](https://github.com/compound-finance/compound-protocol/blob/master/contracts/Timelock.sol) to be used to timelock admin contract calls to the Ren contracts.

Timelock.sol has been audited by OpenZeppelin Security, with the report available [here](https://blog.openzeppelin.com/compound-finance-patch-audit/).