### PR TITLE
DarknodePaymentMigrator and DarknodeRegistryForwarder

### DIFF
--- a/contracts/DarknodePayment/DarknodePaymentMigrator.sol
+++ b/contracts/DarknodePayment/DarknodePaymentMigrator.sol
@@ -1,0 +1,63 @@
+pragma solidity 0.5.17;
+
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/SafeERC20.sol";
+
+import "../Governance/Claimable.sol";
+import "./DarknodePaymentStore.sol";
+import "./DarknodePayment.sol";
+
+/// @notice The DarknodePaymentMigrator migrates unclaimed funds from the
+/// DarknodePayment contract. In a single transaction, it claims the store
+/// ownership from the DNP contract, migrates unclaimed fees and then returns
+/// the store ownership back to the DNP.
+contract DarknodePaymentMigrator is Claimable {
+    DarknodePayment public dnp;
+    address[] public tokens;
+
+    constructor(DarknodePayment _dnp, address[] memory _tokens) public {
+        Claimable.initialize(msg.sender);
+        dnp = _dnp;
+        tokens = _tokens;
+    }
+
+    function claimStoreOwnership() external {
+        require(msg.sender == address(dnp), "Not darknode payment contract");
+        DarknodePaymentStore store = dnp.store();
+
+        store.claimOwnership();
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            address token = tokens[i];
+
+            uint256 unclaimed = store.availableBalance(token);
+
+            store.incrementDarknodeBalance(address(0x0), token, unclaimed);
+
+            store.transfer(
+                address(0x0),
+                token,
+                unclaimed,
+                _payableAddress(owner())
+            );
+        }
+
+        store.transferOwnership(address(dnp));
+        dnp.claimStoreOwnership();
+
+        require(
+            store.owner() == address(dnp),
+            "Store ownership not transferred back."
+        );
+    }
+
+    // Cast an address to a payable address
+    function _payableAddress(address a)
+        internal
+        pure
+        returns (address payable)
+    {
+        return address(uint160(address(a)));
+    }
+}

--- a/contracts/DarknodePayment/DarknodeRegistryForwarder.sol
+++ b/contracts/DarknodePayment/DarknodeRegistryForwarder.sol
@@ -1,0 +1,45 @@
+pragma solidity 0.5.17;
+
+import "../DarknodeRegistry/DarknodeRegistry.sol";
+
+/// @notice DarknodeRegistryForwarder implements the DNR's methods that are used
+/// by the DNP, and it forwards them all to the DNR except
+/// `isRegisteredInPreviousEpoch`, for which it returns false in order to make
+/// calls to `claim` revert.
+contract DarknodeRegistryForwarder {
+    DarknodeRegistryLogicV1 dnr;
+
+    constructor(DarknodeRegistryLogicV1 _dnr) public {
+        dnr = _dnr;
+    }
+
+    /// @notice Returns if a darknode is in the registered state.
+    function isRegistered(address _darknodeID) public view returns (bool) {
+        return dnr.isRegistered(_darknodeID);
+    }
+
+    function currentEpoch() public view returns (uint256, uint256) {
+        return dnr.currentEpoch();
+    }
+
+    function getDarknodeOperator(address _darknodeID)
+        public
+        view
+        returns (address payable)
+    {
+        return dnr.getDarknodeOperator(_darknodeID);
+    }
+
+    function isRegisteredInPreviousEpoch(address _darknodeID)
+        public
+        view
+        returns (bool)
+    {
+        // return dnr.isRegisteredInPreviousEpoch(_darknodeID);
+        return false;
+    }
+
+    function numDarknodesPreviousEpoch() public view returns (uint256) {
+        return dnr.numDarknodesPreviousEpoch();
+    }
+}


### PR DESCRIPTION
These two contracts are required for the migration of darknode rewards from being managed by Ethereum contracts to being in RenVM natively.