### PR TITLE
Make deregistered Darknodes slashable

### DIFF
--- a/contracts/DarknodeRegistry/DarknodeRegistry.sol
+++ b/contracts/DarknodeRegistry/DarknodeRegistry.sol
@@ -184,11 +184,10 @@ contract DarknodeRegistryLogicV1 is
         _;
     }
 
-    /// @notice Restrict a function to registered nodes without a pending
-    /// deregistration.
+    /// @notice Restrict a function to registered and deregistered nodes.
     modifier onlyDarknode(address _darknodeID) {
         require(
-            isRegistered(_darknodeID),
+            isRegistered(_darknodeID) || isDeregistered(_darknodeID),
             "DarknodeRegistry: invalid darknode"
         );
         _;


### PR DESCRIPTION
This PR allows deregistered Darknodes to be slashed. The current implementation would have allowed Darknodes to misbehave, deregister, and call the epoch to make themselves unslashable.