### PR TITLE
Add registerMultiple, deregisterMultiple, & refundMultiple methods

### DIFF
--- a/test/DarknodeRegistry.ts
+++ b/test/DarknodeRegistry.ts
@@ -693,41 +693,13 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         // [CHECK] Refund fails if transfer fails
         await ren.pause();
         await dnr.refund(ID("2")).should.be.rejectedWith(/Pausable: paused/);
-        await ren.unpause();
-
-        // [RESET]
-        await dnr.refund(ID("2"));
-    });
-
-    it("should throw if one of multiple refunds fail", async () => {
-        // [SETUP]
-        await ren.approve(dnr.address, MINIMUM_BOND.mul(new BN(2)), {
-            from: accounts[numAccounts - 1],
-        });
-        await dnr.registerMultiple([ID("2"), ID("3")], {
-            from: accounts[numAccounts - 1],
-        });
-        await waitForEpoch(dnr);
-        await dnr.deregisterMultiple([ID("2"), ID("3")], {
-            from: accounts[numAccounts - 1],
-        });
-        await waitForEpoch(dnr);
-        await waitForEpoch(dnr);
-        await waitForEpoch(dnr);
-
-        // [CHECK] Refund fails if transfer fails
-        await ren.pause();
         await dnr
-            .refundMultiple([ID("2"), ID("3")], {
-                from: accounts[numAccounts - 1],
-            })
+            .refundMultiple([ID("2")])
             .should.be.rejectedWith(/Pausable: paused/);
         await ren.unpause();
 
         // [RESET]
-        await dnr.refundMultiple([ID("2"), ID("3")], {
-            from: accounts[numAccounts - 1],
-        });
+        await dnr.refund(ID("2"));
     });
 
     it("should not refund for an address which is never registered", async () => {


### PR DESCRIPTION
The current `register`, `deregister`, and `refund` methods are inefficient when managing multiple Darknodes. This PR adds `registerMultiple`, `deregisterMultiple`, and `refundMultiple` methods that are optimized for multiple Darknodes. Below are best gas estimates based on Hardhat tests.

`register` vs. `registerMultiple`:

Darknodes | register | registerMultiple | savings
-- | -- | -- | --
1 | 208,312 |   |  
2 | 416,624 | 335,481 | 19.48%
4 | 833,248 | 584,879 | 29.81%
8 | 1,666,496 | 1,083,699 | 34.97%
16 | 3,332,992 | 2,081,339 | 37.55%
32 | 6,665,984 | 4,076,585 | 38.84%
64 | 13,331,968 | 8,067,091 | 39.49%

`deregister` vs. `deregisterMultiple`:

Darknodes | deregister | deregisterMultiple | savings
-- | -- | -- | --
1 | 82,717 |   |  
2 | 165,434 | 117,315 | 29.09%
4 | 330,868 | 187,198 | 43.42%
8 | 661,736 | 327,207 | 50.55%
16 | 1,323,472 | 607,225 | 54.12%
32 | 2,646,944 | 1,167,230 | 55.90%
64 | 5,293,888 | 2,287,267 | 56.79%

`refund` vs. `refundMultiple`:

Darknodes | refund | refundMultiple | savings
-- | -- | -- | --
1 | 117,252 |   |  
2 | 234,504 | 153,340 | 34.61%
4 | 469,008 | 228,840 | 51.21%
8 | 938,016 | 379,899 | 59.50%
16 | 1,876,032 | 682,017 | 63.65%
32 | 3,752,064 | 1,286,227 | 65.72%
64 | 7,504,128 | 2,494,657 | 66.76%

