### PR TITLE
feat: add DarknodeRegistry.recover

### DIFF
--- a/contracts/DarknodeRegistry/DarknodeRegistry.sol
+++ b/contracts/DarknodeRegistry/DarknodeRegistry.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.5.17;
 
 import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/cryptography/ECDSA.sol";
 import "@openzeppelin/upgrades/contracts/upgradeability/InitializableAdminUpgradeabilityProxy.sol";
 import "@openzeppelin/upgrades/contracts/Initializable.sol";
 
@@ -526,6 +527,58 @@ contract DarknodeRegistryLogicV2 is
 
         // Emit an event.
         emit LogDarknodeRefunded(msg.sender, _darknodeID, amount);
+    }
+
+    /// @notice A permissioned method for refunding a darknode without the usual
+    /// delay. The operator must provide a signature of the darknode ID and the
+    /// bond recipient, but the call must come from the contract's owner. The
+    /// main use case is for when an operator's keys have been compromised,
+    /// allowing for the bonds to be recovered by the operator through the
+    /// GatewayRegistry's governance. It is expected that this process would
+    /// happen towards the end of the darknode's deregistered period, so that
+    /// a malicious operator can't use this to quickly exit their stake after
+    /// attempting an attack on the network.
+    function recover(
+        address _darknodeID,
+        address _bondRecipient,
+        bytes calldata _signature
+    ) external onlyOwner {
+        require(
+            isRefundable(_darknodeID) || isDeregistered(_darknodeID),
+            "DarknodeRegistry: must be deregistered"
+        );
+
+        address darknodeOperator = store.darknodeOperator(_darknodeID);
+
+        require(
+            ECDSA.recover(
+                keccak256(
+                    abi.encodePacked(
+                        "\x19Ethereum Signed Message:\n64",
+                        "DarknodeRegistry.recover",
+                        _darknodeID,
+                        _bondRecipient
+                    )
+                ),
+                _signature
+            ) == darknodeOperator,
+            "DarknodeRegistry: invalid signature"
+        );
+
+        // Remember the bond amount
+        uint256 amount = store.darknodeBond(_darknodeID);
+
+        // Erase the darknode from the registry
+        store.removeDarknode(_darknodeID);
+
+        // Refund the operator by transferring REN
+        require(
+            ren.transfer(_bondRecipient, amount),
+            "DarknodeRegistry: bond transfer failed"
+        );
+
+        // Emit an event.
+        emit LogDarknodeRefunded(darknodeOperator, _darknodeID, amount);
     }
 
     /// @notice Refund the bonds of multiple deregistered darknodes. This will

--- a/contracts/DarknodeRegistry/DarknodeRegistry.sol
+++ b/contracts/DarknodeRegistry/DarknodeRegistry.sol
@@ -43,11 +43,24 @@ contract DarknodeRegistryLogicV2 is
 
     /// @notice Emitted when a refund has been made.
     /// @param _darknodeOperator The owner of the darknode.
+    /// @param _darknodeID The ID of the darknode that was refunded.
     /// @param _amount The amount of REN that was refunded.
     event LogDarknodeRefunded(
         address indexed _darknodeOperator,
         address indexed _darknodeID,
         uint256 _amount
+    );
+
+    /// @notice Emitted when a recovery has been made.
+    /// @param _darknodeOperator The owner of the darknode.
+    /// @param _darknodeID The ID of the darknode that was recovered.
+    /// @param _bondRecipient The address that received the bond.
+    /// @param _submitter The address that called the recover method.
+    event LogDarknodeRecovered(
+        address indexed _darknodeOperator,
+        address indexed _darknodeID,
+        address _bondRecipient,
+        address indexed _submitter
     );
 
     /// @notice Emitted when a darknode's bond is slashed.
@@ -537,7 +550,8 @@ contract DarknodeRegistryLogicV2 is
     /// GatewayRegistry's governance. It is expected that this process would
     /// happen towards the end of the darknode's deregistered period, so that
     /// a malicious operator can't use this to quickly exit their stake after
-    /// attempting an attack on the network.
+    /// attempting an attack on the network. It's also expected that the
+    /// operator will not re-register the same darknode again.
     function recover(
         address _darknodeID,
         address _bondRecipient,
@@ -579,6 +593,12 @@ contract DarknodeRegistryLogicV2 is
 
         // Emit an event.
         emit LogDarknodeRefunded(darknodeOperator, _darknodeID, amount);
+        emit LogDarknodeRecovered(
+            darknodeOperator,
+            _darknodeID,
+            _bondRecipient,
+            msg.sender
+        );
     }
 
     /// @notice Refund the bonds of multiple deregistered darknodes. This will

--- a/contracts/DarknodeRegistry/DarknodeRegistryV1ToV2Upgrader.sol
+++ b/contracts/DarknodeRegistry/DarknodeRegistryV1ToV2Upgrader.sol
@@ -1,22 +1,17 @@
 pragma solidity ^0.5.17;
 
-import "@openzeppelin/upgrades/contracts/Initializable.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/cryptography/ECDSA.sol";
-import "@openzeppelin/upgrades/contracts/upgradeability/InitializableAdminUpgradeabilityProxy.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
 
-import "../Governance/Claimable.sol";
 import "./DarknodeRegistry.sol";
 
 import "../Governance/RenProxyAdmin.sol";
 
 contract DarknodeRegistryV1ToV2Upgrader is Ownable {
-    RenProxyAdmin renProxyAdmin;
-    DarknodeRegistryLogicV1 darknodeRegistryProxy;
-    DarknodeRegistryLogicV2 darknodeRegistryLogicV2;
-    address previousAdminOwner;
-    address previousDarknodeRegistryOwner;
+    RenProxyAdmin public renProxyAdmin;
+    DarknodeRegistryLogicV1 public darknodeRegistryProxy;
+    DarknodeRegistryLogicV2 public darknodeRegistryLogicV2;
+    address public previousAdminOwner;
+    address public previousDarknodeRegistryOwner;
 
     constructor(
         RenProxyAdmin _renProxyAdmin,

--- a/contracts/DarknodeRegistry/DarknodeRegistryV1ToV2Upgrader.sol
+++ b/contracts/DarknodeRegistry/DarknodeRegistryV1ToV2Upgrader.sol
@@ -1,0 +1,133 @@
+pragma solidity ^0.5.17;
+
+import "@openzeppelin/upgrades/contracts/Initializable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/cryptography/ECDSA.sol";
+import "@openzeppelin/upgrades/contracts/upgradeability/InitializableAdminUpgradeabilityProxy.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
+
+import "../Governance/Claimable.sol";
+import "./DarknodeRegistry.sol";
+
+import "../Governance/RenProxyAdmin.sol";
+
+contract DarknodeRegistryV1ToV2Upgrader is Ownable {
+    RenProxyAdmin renProxyAdmin;
+    DarknodeRegistryLogicV1 darknodeRegistryProxy;
+    DarknodeRegistryLogicV2 darknodeRegistryLogicV2;
+    address previousAdminOwner;
+    address previousDarknodeRegistryOwner;
+
+    constructor(
+        RenProxyAdmin _renProxyAdmin,
+        DarknodeRegistryLogicV1 _darknodeRegistryProxy,
+        DarknodeRegistryLogicV2 _darknodeRegistryLogicV2
+    ) public {
+        Ownable.initialize(msg.sender);
+        renProxyAdmin = _renProxyAdmin;
+        darknodeRegistryProxy = _darknodeRegistryProxy;
+        darknodeRegistryLogicV2 = _darknodeRegistryLogicV2;
+        previousAdminOwner = renProxyAdmin.owner();
+        previousDarknodeRegistryOwner = darknodeRegistryProxy.owner();
+    }
+
+    function upgrade() public onlyOwner {
+        // Pre-checks
+        uint256 numDarknodes = darknodeRegistryProxy.numDarknodes();
+        uint256 numDarknodesNextEpoch = darknodeRegistryProxy
+            .numDarknodesNextEpoch();
+        uint256 numDarknodesPreviousEpoch = darknodeRegistryProxy
+            .numDarknodesPreviousEpoch();
+        uint256 minimumBond = darknodeRegistryProxy.minimumBond();
+        uint256 minimumPodSize = darknodeRegistryProxy.minimumPodSize();
+        uint256 minimumEpochInterval = darknodeRegistryProxy
+            .minimumEpochInterval();
+        uint256 deregistrationInterval = darknodeRegistryProxy
+            .deregistrationInterval();
+        RenToken ren = darknodeRegistryProxy.ren();
+        DarknodeRegistryStore store = darknodeRegistryProxy.store();
+        IDarknodePayment darknodePayment = darknodeRegistryProxy
+            .darknodePayment();
+
+        // Claim and update.
+        darknodeRegistryProxy.claimOwnership();
+        renProxyAdmin.upgrade(
+            AdminUpgradeabilityProxy(
+                // Cast gateway instance to payable address
+                address(uint160(address(darknodeRegistryProxy)))
+            ),
+            address(darknodeRegistryLogicV2)
+        );
+
+        // Post-checks
+        require(
+            numDarknodes == darknodeRegistryProxy.numDarknodes(),
+            "Migrator: expected 'numDarknodes' not to change"
+        );
+        require(
+            numDarknodesNextEpoch ==
+                darknodeRegistryProxy.numDarknodesNextEpoch(),
+            "Migrator: expected 'numDarknodesNextEpoch' not to change"
+        );
+        require(
+            numDarknodesPreviousEpoch ==
+                darknodeRegistryProxy.numDarknodesPreviousEpoch(),
+            "Migrator: expected 'numDarknodesPreviousEpoch' not to change"
+        );
+        require(
+            minimumBond == darknodeRegistryProxy.minimumBond(),
+            "Migrator: expected 'minimumBond' not to change"
+        );
+        require(
+            minimumPodSize == darknodeRegistryProxy.minimumPodSize(),
+            "Migrator: expected 'minimumPodSize' not to change"
+        );
+        require(
+            minimumEpochInterval ==
+                darknodeRegistryProxy.minimumEpochInterval(),
+            "Migrator: expected 'minimumEpochInterval' not to change"
+        );
+        require(
+            deregistrationInterval ==
+                darknodeRegistryProxy.deregistrationInterval(),
+            "Migrator: expected 'deregistrationInterval' not to change"
+        );
+        require(
+            ren == darknodeRegistryProxy.ren(),
+            "Migrator: expected 'ren' not to change"
+        );
+        require(
+            store == darknodeRegistryProxy.store(),
+            "Migrator: expected 'store' not to change"
+        );
+        require(
+            darknodePayment == darknodeRegistryProxy.darknodePayment(),
+            "Migrator: expected 'darknodePayment' not to change"
+        );
+
+        darknodeRegistryProxy.updateSlasher(IDarknodeSlasher(0x0));
+    }
+
+    function recover(
+        address _darknodeID,
+        address _bondRecipient,
+        bytes calldata _signature
+    ) external onlyOwner {
+        return
+            DarknodeRegistryLogicV2(address(darknodeRegistryProxy)).recover(
+                _darknodeID,
+                _bondRecipient,
+                _signature
+            );
+    }
+
+    function returnDNR() public onlyOwner {
+        darknodeRegistryProxy._directTransferOwnership(
+            previousDarknodeRegistryOwner
+        );
+    }
+
+    function returnProxyAdmin() public onlyOwner {
+        renProxyAdmin.transferOwnership(previousAdminOwner);
+    }
+}

--- a/contracts/Governance/Claimable.sol
+++ b/contracts/Governance/Claimable.sol
@@ -31,6 +31,12 @@ contract Claimable is Initializable, Ownable {
         pendingOwner = newOwner;
     }
 
+    // Allow skipping two-step transfer if the recipient is known to be a valid
+    // owner, for use in smart-contracts only.
+    function _directTransferOwnership(address newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
     function claimOwnership() public onlyPendingOwner {
         _transferOwnership(pendingOwner);
         delete pendingOwner;

--- a/migrations/1_darknodes.js
+++ b/migrations/1_darknodes.js
@@ -6,6 +6,9 @@ const RenToken = artifacts.require("RenToken");
 const DarknodeRegistryStore = artifacts.require("DarknodeRegistryStore");
 const DarknodeRegistryProxy = artifacts.require("DarknodeRegistryProxy");
 const DarknodeRegistryLogicV2 = artifacts.require("DarknodeRegistryLogicV2");
+const DarknodeRegistryV1ToV2Upgrader = artifacts.require(
+    "DarknodeRegistryV1ToV2Upgrader"
+);
 const RenProxyAdmin = artifacts.require("RenProxyAdmin");
 
 const networks = require("./networks.js");
@@ -52,6 +55,8 @@ module.exports = async function (deployer, network) {
     DarknodeRegistryLogicV2.address = addresses.DarknodeRegistryLogicV2 || "";
     DarknodeRegistryStore.address = addresses.DarknodeRegistryStore || "";
     RenProxyAdmin.address = addresses.RenProxyAdmin || "";
+    DarknodeRegistryV1ToV2Upgrader.address =
+        addresses.DarknodeRegistryV1ToV2Upgrader || "";
 
     const slasher = NULL;
 
@@ -234,12 +239,22 @@ module.exports = async function (deployer, network) {
         );
     }
 
-    const currentSlasher = await darknodeRegistry.slasher();
-    const nextSlasher = await darknodeRegistry.nextSlasher();
-    if (Ox(currentSlasher) != Ox(slasher) && Ox(nextSlasher) != Ox(slasher)) {
-        deployer.logger.log("Linking DarknodeSlasher and DarknodeRegistry");
-        // Update slasher address
-        await darknodeRegistry.updateSlasher(slasher);
+    // const currentSlasher = await darknodeRegistry.slasher();
+    // const nextSlasher = await darknodeRegistry.nextSlasher();
+    // if (Ox(currentSlasher) != Ox(slasher) && Ox(nextSlasher) != Ox(slasher)) {
+    //     deployer.logger.log("Linking DarknodeSlasher and DarknodeRegistry");
+    //     // Update slasher address
+    //     await darknodeRegistry.updateSlasher(slasher);
+    //     actionCount++;
+    // }
+
+    if (!DarknodeRegistryV1ToV2Upgrader.address) {
+        await deployer.deploy(
+            DarknodeRegistryV1ToV2Upgrader,
+            renProxyAdmin.address,
+            darknodeRegistry.address,
+            darknodeRegistryLogic.address
+        );
         actionCount++;
     }
 
@@ -251,5 +266,6 @@ module.exports = async function (deployer, network) {
         DarknodeRegistryStore: "${DarknodeRegistryStore.address}",
         DarknodeRegistryLogicV2: "${DarknodeRegistryLogicV2.address}",
         DarknodeRegistryProxy: "${DarknodeRegistryProxy.address}",
+        DarknodeRegistryV1ToV2Upgrader: "${DarknodeRegistryV1ToV2Upgrader.address}",
     `);
 };

--- a/migrations/networks.js
+++ b/migrations/networks.js
@@ -7,7 +7,7 @@ const config = {
     DARKNODE_PAYOUT_PERCENT: 50, // Only payout 50% of the reward pool
     BLACKLIST_SLASH_PERCENT: 0, // Don't slash bond for blacklisting
     MALICIOUS_SLASH_PERCENT: 50, // Slash 50% of the bond
-    SECRET_REVEAL_SLASH_PERCENT: 100 // Slash 100% of the bond
+    SECRET_REVEAL_SLASH_PERCENT: 100, // Slash 100% of the bond
 };
 
 module.exports = {
@@ -24,6 +24,8 @@ module.exports = {
         DarknodeRegistryStore: "0x60Ab11FE605D2A2C3cf351824816772a131f8782",
         DarknodeRegistryLogicV1: "0x33b53A700de61b6be01d65A758b3635584bCF140",
         DarknodeRegistryProxy: "0x2D7b6C95aFeFFa50C068D50f89C5C0014e054f0A",
+        DarknodeRegistryLogicV2: "",
+        DarknodeRegistryV1ToV2Upgrader: "",
 
         // DNP
         DarknodePaymentStore: "0xE33417797d6b8Aec9171d0d6516E88002fbe23E7",
@@ -31,12 +33,12 @@ module.exports = {
 
         tokens: {
             DAI: "0x6b175474e89094c44da98b954eedeac495271d0f",
-            ETH: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+            ETH: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         },
 
         config: {
-            ...config
-        }
+            ...config,
+        },
     },
     testnet: {
         RenProxyAdmin: "0x4C695C4Aa6238f0A7092733180328c2E64C912C7",
@@ -50,7 +52,10 @@ module.exports = {
         // DNR
         DarknodeRegistryStore: "0x9daa16aA19e37f3de06197a8B5E638EC5e487392",
         DarknodeRegistryLogicV1: "0x046EDe9916e13De79d5530b67FF5dEbB7B72742C",
+        DarknodeRegistryLogicV2: "0x61ffD5059Af59D480C57d43DCC09eea653e95eC8",
         DarknodeRegistryProxy: "0x9954C9F839b31E82bc9CA98F234313112D269712",
+        DarknodeRegistryV1ToV2Upgrader:
+            "0x6587720afB2b306b1888408B907E2A4DD8B18651",
 
         // DNP
         DarknodePaymentStore: "0x0EC73cCDCd8e643d909D0c4b663Eb1B2Fb0b1e1C",
@@ -58,12 +63,12 @@ module.exports = {
 
         tokens: {
             DAI: "0xc4375b7de8af5a38a93548eb8453a498222c4ff2",
-            ETH: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+            ETH: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         },
 
         config: {
-            ...config
-        }
+            ...config,
+        },
     },
 
     devnet: {
@@ -79,6 +84,8 @@ module.exports = {
         DarknodeRegistryStore: "0x3ccF0cd02ff15b59Ce2B152CdDE78551eFd34a62",
         DarknodeRegistryLogicV1: "0x26D6fEC1C904EB5b86ACed6BB804b4ed35208704",
         DarknodeRegistryProxy: "0x7B69e5e15D4c24c353Fea56f72E4C0c5B93dCb71",
+        DarknodeRegistryLogicV2: "",
+        DarknodeRegistryV1ToV2Upgrader: "",
 
         // DNP
         DarknodePaymentStore: "0xfb98D6900330844CeAce6Ae4ae966D272bE1aeC3",
@@ -86,13 +93,13 @@ module.exports = {
 
         tokens: {
             DAI: "0xc4375b7de8af5a38a93548eb8453a498222c4ff2",
-            ETH: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+            ETH: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         },
 
         config: {
-            ...config
-        }
+            ...config,
+        },
     },
 
-    config
+    config,
 };

--- a/test/DarknodeRegistryMigration.ts
+++ b/test/DarknodeRegistryMigration.ts
@@ -1,0 +1,444 @@
+import BN from "bn.js";
+
+import {
+    DarknodeRegistryLogicV1Instance,
+    DarknodeRegistryLogicV2Instance,
+    DarknodeRegistryStoreInstance,
+    DarknodeRegistryV1ToV2UpgraderInstance,
+    RenProxyAdminInstance,
+    RenTokenInstance,
+} from "../types/truffle-contracts";
+import {
+    encodeCallData,
+    ID,
+    MINIMUM_BOND,
+    PUBK,
+    signRecoverMessage,
+    waitForEpoch,
+} from "./helper/testUtils";
+
+const RenToken = artifacts.require("RenToken");
+const DarknodeRegistryStore = artifacts.require("DarknodeRegistryStore");
+const DarknodeRegistryProxy = artifacts.require("DarknodeRegistryProxy");
+const DarknodeRegistryLogicV2 = artifacts.require("DarknodeRegistryLogicV2");
+const DarknodeRegistryLogicV1 = artifacts.require("DarknodeRegistryLogicV1");
+const RenProxyAdmin = artifacts.require("RenProxyAdmin");
+const DarknodeRegistryV1ToV2Upgrader = artifacts.require(
+    "DarknodeRegistryV1ToV2Upgrader"
+);
+
+const { config } = require("../migrations/networks");
+
+const numAccounts = 10;
+
+contract("DarknodeRegistryV1ToV2Upgrader", (accounts: string[]) => {
+    let ren: RenTokenInstance;
+    let dnrV1: DarknodeRegistryLogicV1Instance;
+    let dnrV2: DarknodeRegistryLogicV2Instance;
+    let darknodeRegistryLogicV1: DarknodeRegistryLogicV1Instance;
+    let darknodeRegistryLogicV2: DarknodeRegistryLogicV2Instance;
+    let renProxyAdmin: RenProxyAdminInstance;
+    let upgrader: DarknodeRegistryV1ToV2UpgraderInstance;
+
+    before(async () => {
+        ren = await RenToken.deployed();
+        renProxyAdmin = await RenProxyAdmin.deployed();
+
+        const dnrs = await DarknodeRegistryStore.new("1", RenToken.address);
+
+        darknodeRegistryLogicV1 = await DarknodeRegistryLogicV1.new();
+        darknodeRegistryLogicV2 = await DarknodeRegistryLogicV2.new();
+        const darknodeRegistryParameters = {
+            types: [
+                "string",
+                "address",
+                "address",
+                "uint256",
+                "uint256",
+                "uint256",
+                "uint256",
+            ],
+            values: [
+                "1",
+                RenToken.address,
+                dnrs.address,
+                config.MINIMUM_BOND.toString(),
+                config.MINIMUM_POD_SIZE,
+                config.MINIMUM_EPOCH_INTERVAL_SECONDS,
+                0,
+            ],
+        };
+
+        const darknodeRegistryProxy = await DarknodeRegistryProxy.new();
+        await darknodeRegistryProxy.methods[
+            "initialize(address,address,bytes)"
+        ](
+            darknodeRegistryLogicV1.address,
+            renProxyAdmin.address,
+            encodeCallData(
+                web3,
+                "initialize",
+                darknodeRegistryParameters.types,
+                darknodeRegistryParameters.values
+            )
+        );
+        dnrV1 = await DarknodeRegistryLogicV1.at(darknodeRegistryProxy.address);
+        dnrV2 = await DarknodeRegistryLogicV2.at(darknodeRegistryProxy.address);
+
+        await dnrs.transferOwnership(dnrV1.address);
+        await dnrV1.claimStoreOwnership();
+
+        await waitForEpoch(dnrV1);
+        await waitForEpoch(dnrV1);
+
+        for (let i = 1; i < numAccounts; i++) {
+            await ren.transfer(accounts[i], MINIMUM_BOND);
+        }
+
+        // Transfer accounts[numAccounts - 1] an additional MINIMUM_BOND so it can
+        // register, deregister, and refund multiple darknodes
+        await ren.transfer(accounts[numAccounts - 1], MINIMUM_BOND);
+
+        upgrader = await DarknodeRegistryV1ToV2Upgrader.new(
+            renProxyAdmin.address,
+            darknodeRegistryProxy.address,
+            darknodeRegistryLogicV2.address,
+            { from: accounts[0] }
+        );
+    });
+
+    it("can register, deregister and refund Darknodes", async function () {
+        this.timeout(1000 * 1000);
+        // [ACTION] Register
+        for (let i = 0; i < numAccounts; i++) {
+            await ren.approve(dnrV1.address, MINIMUM_BOND, {
+                from: accounts[i],
+            });
+            await dnrV1.register(ID(i), PUBK(i), { from: accounts[i] });
+        }
+
+        const nodeCount = 10;
+        await ren.transfer(accounts[2], MINIMUM_BOND.mul(new BN(nodeCount)));
+        await ren.approve(dnrV1.address, MINIMUM_BOND.mul(new BN(nodeCount)), {
+            from: accounts[2],
+        });
+
+        for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+            await dnrV1.register(ID(i), PUBK(i), { from: accounts[2] });
+        }
+
+        // Wait for epoch
+        await waitForEpoch(dnrV1);
+
+        // [ACTION] Deregister
+        for (let i = 0; i < numAccounts; i++) {
+            await dnrV1.deregister(ID(i), { from: accounts[i] });
+        }
+
+        for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+            await dnrV1.deregister(ID(i), { from: accounts[2] });
+        }
+
+        // Wait for two epochs
+        await waitForEpoch(dnrV1);
+        await waitForEpoch(dnrV1);
+
+        // [ACTION] Refund
+        for (let i = 0; i < numAccounts; i++) {
+            await dnrV1.refund(ID(i), { from: accounts[i] });
+        }
+
+        for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+            await dnrV1.refund(ID(i), { from: accounts[2] });
+        }
+
+        await ren.transfer(accounts[0], MINIMUM_BOND.mul(new BN(nodeCount)), {
+            from: accounts[2],
+        });
+    });
+
+    // it("can upgrade", async function () {
+    //     /** **** UPGRADE **** */
+    //     await dnrV1.transferOwnership(upgrader.address, { from: accounts[0] });
+    //     await renProxyAdmin.transferOwnership(upgrader.address, {
+    //         from: accounts[0],
+    //     });
+
+    //     await upgrader.upgrade({ from: accounts[0] });
+
+    //     await upgrader.returnDNR();
+    //     await upgrader.returnProxyAdmin();
+    //     /** **** **** */
+    // });
+
+    // it("should be able to recover a darknode's bond", async function () {
+    //     this.timeout(1000 * 1000);
+
+    //     // [ACTION] Register
+    //     for (let i = 0; i < numAccounts; i++) {
+    //         await ren.approve(dnrV2.address, MINIMUM_BOND, {
+    //             from: accounts[i],
+    //         });
+    //         await dnrV2.register(ID(i), PUBK(i), { from: accounts[i] });
+    //     }
+
+    //     const nodeCount = 10;
+    //     await ren.transfer(accounts[2], MINIMUM_BOND.mul(new BN(nodeCount)));
+    //     await ren.approve(dnrV2.address, MINIMUM_BOND.mul(new BN(nodeCount)), {
+    //         from: accounts[2],
+    //     });
+
+    //     for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+    //         await dnrV2.register(ID(i), PUBK(i), { from: accounts[2] });
+    //     }
+
+    //     // Wait for epoch
+    //     await waitForEpoch(dnrV2);
+
+    //     (
+    //         await dnrV2.getOperatorDarknodes(accounts[2])
+    //     ).length.should.bignumber.equal(nodeCount + 1); // +1 from the first loop
+
+    //     const recovered: number[] = [];
+
+    //     // [ACTION] Deregister
+    //     for (let i = 0; i < numAccounts; i++) {
+    //         await dnrV2.deregister(ID(i), { from: accounts[i] });
+    //     }
+
+    //     for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+    //         if (recovered.indexOf(i) >= 0) {
+    //             continue;
+    //         }
+    //         await dnrV2.deregister(ID(i), { from: accounts[2] });
+    //     }
+
+    //     // Wait for two epochs
+    //     await waitForEpoch(dnrV2);
+
+    //     // Recover
+    //     const darknodeOperator = accounts[2];
+    //     const recipient = accounts[3];
+    //     const recipientBalanceBefore = await ren.balanceOf(recipient);
+    //     const darknodeToRefund = numAccounts;
+    //     const signature = await signRecoverMessage(
+    //         darknodeOperator,
+    //         recipient,
+    //         ID(darknodeToRefund)
+    //     );
+    //     await dnrV2.recover(ID(darknodeToRefund), recipient, signature, {
+    //         from: accounts[0],
+    //     });
+    //     recovered.push(darknodeToRefund);
+
+    //     const recipientBalanceAfter = await ren.balanceOf(recipient);
+    //     recipientBalanceAfter
+    //         .sub(recipientBalanceBefore)
+    //         .should.bignumber.equal(await dnrV2.minimumBond());
+    //     await ren.transfer(darknodeOperator, await dnrV2.minimumBond(), {
+    //         from: recipient,
+    //     });
+    //     (
+    //         await dnrV2.getOperatorDarknodes(accounts[2])
+    //     ).length.should.bignumber.equal(nodeCount);
+
+    //     await waitForEpoch(dnrV2);
+
+    //     // Recover
+    //     const signatureThree = await signRecoverMessage(
+    //         darknodeOperator,
+    //         recipient,
+    //         ID(darknodeToRefund + 1)
+    //     );
+    //     await dnrV2.recover(
+    //         ID(darknodeToRefund + 1),
+    //         recipient,
+    //         signatureThree,
+    //         {
+    //             from: accounts[0],
+    //         }
+    //     );
+    //     recovered.push(darknodeToRefund + 1);
+
+    //     // [ACTION] Refund
+    //     for (let i = 0; i < numAccounts; i++) {
+    //         await dnrV2.refund(ID(i), { from: accounts[i] });
+    //     }
+
+    //     for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+    //         if (recovered.indexOf(i) >= 0) {
+    //             continue;
+    //         }
+    //         await dnrV2.refund(ID(i), { from: accounts[2] });
+    //     }
+
+    //     await ren.transfer(accounts[0], MINIMUM_BOND.mul(new BN(nodeCount)), {
+    //         from: accounts[2],
+    //     });
+    // });
+
+    it("can upgrade", async function () {
+        this.timeout(1000 * 1000);
+
+        // [ACTION] Register
+        for (let i = 0; i < numAccounts; i++) {
+            await ren.approve(dnrV1.address, MINIMUM_BOND, {
+                from: accounts[i],
+            });
+            await dnrV1.register(ID(i), PUBK(i), { from: accounts[i] });
+        }
+
+        const nodeCount = 10;
+        await ren.transfer(accounts[2], MINIMUM_BOND.mul(new BN(nodeCount)));
+        await ren.approve(dnrV1.address, MINIMUM_BOND.mul(new BN(nodeCount)), {
+            from: accounts[2],
+        });
+
+        for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+            await dnrV1.register(ID(i), PUBK(i), { from: accounts[2] });
+        }
+
+        // Wait for epoch
+        await waitForEpoch(dnrV1);
+
+        const recovered: number[] = [];
+
+        // [ACTION] Deregister
+        for (let i = 0; i < numAccounts; i++) {
+            await dnrV1.deregister(ID(i), { from: accounts[i] });
+        }
+
+        for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+            if (recovered.indexOf(i) >= 0) {
+                continue;
+            }
+            await dnrV1.deregister(ID(i), { from: accounts[2] });
+        }
+
+        // Wait for two epochs
+        await waitForEpoch(dnrV1);
+
+        /** **** UPGRADE **** */
+        await dnrV1.transferOwnership(upgrader.address, { from: accounts[0] });
+        await renProxyAdmin.transferOwnership(upgrader.address, {
+            from: accounts[0],
+        });
+
+        await upgrader.upgrade({ from: accounts[0] });
+
+        await upgrader.returnDNR();
+        await upgrader.returnProxyAdmin();
+        /** **** **** */
+
+        // Recover
+        const darknodeOperator = accounts[2];
+        const recipient = accounts[3];
+        const recipientBalanceBefore = await ren.balanceOf(recipient);
+        const darknodeToRefund = numAccounts;
+        const signature = await signRecoverMessage(
+            darknodeOperator,
+            recipient,
+            ID(darknodeToRefund)
+        );
+        await dnrV2.recover(ID(darknodeToRefund), recipient, signature, {
+            from: accounts[0],
+        });
+        recovered.push(darknodeToRefund);
+
+        const recipientBalanceAfter = await ren.balanceOf(recipient);
+        recipientBalanceAfter
+            .sub(recipientBalanceBefore)
+            .should.bignumber.equal(await dnrV2.minimumBond());
+        await ren.transfer(darknodeOperator, await dnrV2.minimumBond(), {
+            from: recipient,
+        });
+
+        await waitForEpoch(dnrV2);
+
+        // Recover
+        const signatureThree = await signRecoverMessage(
+            darknodeOperator,
+            recipient,
+            ID(darknodeToRefund + 1)
+        );
+        await dnrV2.recover(
+            ID(darknodeToRefund + 1),
+            recipient,
+            signatureThree,
+            {
+                from: accounts[0],
+            }
+        );
+        recovered.push(darknodeToRefund + 1);
+
+        // [ACTION] Refund
+        for (let i = 0; i < numAccounts; i++) {
+            await dnrV2.refund(ID(i), { from: accounts[i] });
+        }
+
+        for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+            if (recovered.indexOf(i) >= 0) {
+                continue;
+            }
+            await dnrV2.refund(ID(i), { from: accounts[2] });
+        }
+
+        await ren.transfer(accounts[0], MINIMUM_BOND.mul(new BN(nodeCount)), {
+            from: accounts[2],
+        });
+    });
+
+    // it("can register, deregister and refund Darknodes", async function () {
+    //     this.timeout(1000 * 1000);
+    //     // [ACTION] Register
+    //     for (let i = 0; i < numAccounts; i++) {
+    //         await ren.approve(dnrV2.address, MINIMUM_BOND, {
+    //             from: accounts[i],
+    //         });
+    //         await dnrV2.register(ID(i), PUBK(i), { from: accounts[i] });
+    //     }
+
+    //     const nodeCount = 10;
+    //     await ren.transfer(accounts[2], MINIMUM_BOND.mul(new BN(nodeCount)));
+    //     await ren.approve(dnrV2.address, MINIMUM_BOND.mul(new BN(nodeCount)), {
+    //         from: accounts[2],
+    //     });
+
+    //     for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+    //         await dnrV2.register(ID(i), PUBK(i), { from: accounts[2] });
+    //     }
+
+    //     // Wait for epoch
+    //     await waitForEpoch(dnrV2);
+
+    //     (
+    //         await dnrV2.getOperatorDarknodes(accounts[2])
+    //     ).length.should.bignumber.equal(nodeCount + 1); // +1 from the first loop
+
+    //     // [ACTION] Deregister
+    //     for (let i = 0; i < numAccounts; i++) {
+    //         await dnrV2.deregister(ID(i), { from: accounts[i] });
+    //     }
+
+    //     for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+    //         await dnrV2.deregister(ID(i), { from: accounts[2] });
+    //     }
+
+    //     // Wait for two epochs
+    //     await waitForEpoch(dnrV2);
+    //     await waitForEpoch(dnrV2);
+
+    //     // [ACTION] Refund
+    //     for (let i = 0; i < numAccounts; i++) {
+    //         await dnrV2.refund(ID(i), { from: accounts[i] });
+    //     }
+
+    //     for (let i = numAccounts; i < numAccounts + nodeCount; i++) {
+    //         await dnrV2.refund(ID(i), { from: accounts[2] });
+    //     }
+
+    //     await ren.transfer(accounts[0], MINIMUM_BOND.mul(new BN(nodeCount)), {
+    //         from: accounts[2],
+    //     });
+    // });
+});

--- a/test/DarknodeRegistryMigration.ts
+++ b/test/DarknodeRegistryMigration.ts
@@ -31,7 +31,7 @@ const { config } = require("../migrations/networks");
 
 const numAccounts = 10;
 
-contract("DarknodeRegistryV1ToV2Upgrader", (accounts: string[]) => {
+contract.only("DarknodeRegistryV1ToV2Upgrader", (accounts: string[]) => {
     let ren: RenTokenInstance;
     let dnrV1: DarknodeRegistryLogicV1Instance;
     let dnrV2: DarknodeRegistryLogicV2Instance;
@@ -325,9 +325,6 @@ contract("DarknodeRegistryV1ToV2Upgrader", (accounts: string[]) => {
         });
 
         await upgrader.upgrade({ from: accounts[0] });
-
-        await upgrader.returnDNR();
-        await upgrader.returnProxyAdmin();
         /** **** **** */
 
         // Recover
@@ -340,10 +337,13 @@ contract("DarknodeRegistryV1ToV2Upgrader", (accounts: string[]) => {
             recipient,
             ID(darknodeToRefund)
         );
-        await dnrV2.recover(ID(darknodeToRefund), recipient, signature, {
+        await upgrader.recover(ID(darknodeToRefund), recipient, signature, {
             from: accounts[0],
         });
         recovered.push(darknodeToRefund);
+
+        await upgrader.returnDNR();
+        await upgrader.returnProxyAdmin();
 
         const recipientBalanceAfter = await ren.balanceOf(recipient);
         recipientBalanceAfter

--- a/test/helper/testUtils.ts
+++ b/test/helper/testUtils.ts
@@ -250,3 +250,27 @@ export const toBN = <
 };
 
 export const range = (n: number) => Array.from(new Array(n)).map((_, i) => i);
+
+export const signRecoverMessage = async (
+    owner: string,
+    recipient: string,
+    darknodeID: string
+) => {
+    // Recover
+    const signature = Buffer.from(
+        (
+            await web3.eth.sign(
+                "0x" +
+                    Buffer.concat([
+                        Buffer.from("DarknodeRegistry.recover"),
+                        Buffer.from(ID(darknodeID).slice(2), "hex"),
+                        Buffer.from(recipient.slice(2), "hex"),
+                    ]).toString("hex"),
+                owner
+            )
+        ).slice(2),
+        "hex"
+    );
+    signature[64] = (signature[64] % 27) + 27;
+    return "0x" + signature.toString("hex");
+};

--- a/test/helper/testUtils.ts
+++ b/test/helper/testUtils.ts
@@ -12,7 +12,10 @@ import { ECDSASignature } from "ethereumjs-util";
 import { TransactionReceipt } from "web3-core";
 import { keccak256, toChecksumAddress } from "web3-utils";
 
-import { DarknodeRegistryLogicV2Instance } from "../../types/truffle-contracts";
+import {
+    DarknodeRegistryLogicV1Instance,
+    DarknodeRegistryLogicV2Instance,
+} from "../../types/truffle-contracts";
 
 const ERC20 = artifacts.require("PaymentToken");
 
@@ -121,7 +124,9 @@ export const increaseTime = async (seconds: number) => {
     } while (currentTimestamp < target);
 };
 
-export async function waitForEpoch(dnr: DarknodeRegistryLogicV2Instance) {
+export async function waitForEpoch(
+    dnr: DarknodeRegistryLogicV1Instance | DarknodeRegistryLogicV2Instance
+) {
     // const timeout = MINIMUM_EPOCH_INTERVAL_SECONDS;
     const timeout = new BN(
         (await dnr.minimumEpochInterval()).toString()
@@ -263,7 +268,7 @@ export const signRecoverMessage = async (
                 "0x" +
                     Buffer.concat([
                         Buffer.from("DarknodeRegistry.recover"),
-                        Buffer.from(ID(darknodeID).slice(2), "hex"),
+                        Buffer.from(darknodeID.slice(2), "hex"),
                         Buffer.from(recipient.slice(2), "hex"),
                     ]).toString("hex"),
                 owner


### PR DESCRIPTION
'recover' allows a darknode operator and the DarknodeRegistry's governance to cooperate in recovering a bond when the operator's keys are compromised. A signature from the operator is required.